### PR TITLE
[FEAT] Global Exception, Test, Restdocs 설정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,8 @@
+= S-TOP Rest Docs
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:seclinks:
+
+// include::eventPeriod.adoc[] 컨트롤러별로 주석 지우고 문서 추가

--- a/src/main/java/com/scg/stop/global/exception/BadRequestException.java
+++ b/src/main/java/com/scg/stop/global/exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package com.scg.stop.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BadRequestException extends RuntimeException {
+
+    private final String message;
+}

--- a/src/main/java/com/scg/stop/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/scg/stop/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -16,6 +17,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
@@ -24,6 +26,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             HttpHeaders headers,
             HttpStatusCode status,
             WebRequest request) {
+
+        log.warn(ex.getMessage(), ex);
 
         Map<String, Object> body = new HashMap<>();
 
@@ -42,6 +46,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<Object> handleBadRequestException(BadRequestException ex) {
+
+        log.warn(ex.getMessage(), ex);
+
         Map<String, Object> body = new HashMap<>();
 
         body.put("status", 400);

--- a/src/main/java/com/scg/stop/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/scg/stop/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,54 @@
+package com.scg.stop.global.exception;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+
+        Map<String, Object> body = new HashMap<>();
+
+        body.put("status", 400);
+        body.put("timestamp", LocalDateTime.now());
+        body.put("error", HttpStatus.BAD_REQUEST);
+
+        List<String> errors = ex.getBindingResult().getFieldErrors()
+                .stream()
+                .map(e -> e.getDefaultMessage())
+                .collect(Collectors.toList());
+        body.put("messages", errors);
+
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Object> handleBadRequestException(BadRequestException ex) {
+        Map<String, Object> body = new HashMap<>();
+
+        body.put("status", 400);
+        body.put("timestamp", LocalDateTime.now());
+        body.put("error", HttpStatus.BAD_REQUEST);
+        body.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/test/java/com/scg/stop/configuration/AbstractControllerTest.java
+++ b/src/test/java/com/scg/stop/configuration/AbstractControllerTest.java
@@ -1,0 +1,39 @@
+package com.scg.stop.configuration;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@Import(RestDocsConfiguration.class)
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class AbstractControllerTest {
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(
+            final WebApplicationContext context,
+            final RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentation))
+                .alwaysDo(MockMvcResultHandlers.print())
+                .alwaysDo(restDocs)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+}

--- a/src/test/java/com/scg/stop/configuration/RestDocsConfiguration.java
+++ b/src/test/java/com/scg/stop/configuration/RestDocsConfiguration.java
@@ -1,0 +1,20 @@
+package com.scg.stop.configuration;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+@TestConfiguration
+public class RestDocsConfiguration {
+
+    @Bean
+    public RestDocumentationResultHandler write() {
+        return MockMvcRestDocumentation.document(
+                "{class-name}/{method-name}",
+                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+        );
+    }
+}

--- a/src/test/java/com/scg/stop/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/java/com/scg/stop/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,10 @@
+|===
+    |필드명|타입|필수값|설명
+
+{{#fields}}
+    |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+    |===

--- a/src/test/java/com/scg/stop/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/java/com/scg/stop/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,10 +1,10 @@
 |===
-    |필드명|타입|필수값|설명
+|필드명|타입|필수값|설명
 
 {{#fields}}
-    |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
-    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
-    |{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
-    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
 {{/fields}}
-    |===
+|===


### PR DESCRIPTION
작성자: @yesjuhee 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

Exception, Test, Restdocs 설정 관련 파일들 우선 머지하기 위해 따로 브랜치 파서 PR 올립니다!

### Exception 설정
1. `GlobalExceptionHandler`의 `handleMethodArgumentNotValid` 메서드로 Validation 관련 exception 포멧을 설정했습니다.
    validation 관련 어노테이션의 "message"에 작성한 내용을 깔끔하게 응답 바디에 넣어줍니다.
    ![image](https://github.com/user-attachments/assets/95958ad0-ad40-4f37-889c-aa6a3d2154ae)
2. `BadRequestException`을 추가했습니다.
     사용예시:
    ```java
    if (eventPeriodRepository.existsByYear(createEventPeriodRequest.getYear())) {
            throw new BadRequestException(createEventPeriodRequest.getYear() + "년의 행사 기간이 이미 존재합니다.");
    }
    ```
    결과:
    <img width="459" alt="image" src="https://github.com/user-attachments/assets/bb873c13-10ff-4b7b-8594-f978e32e0644">

### Test/Restdocs 설정
1. `AbstractControllerTest`: 컨트롤러 테스트에 상속시키면 테스트에 Restdocs 설정을 자동으로 할 수 있습니다.
2. `RestDocsConfiguration`: RestDocs prettyprint 설정
3. `src/docs/asciidoc/index.adoc`: Restdocs 시작 페이지 설정
4. `request-fields.snippet`: 요청 필드 템플릿 (required field 여부 표시 가능)

## 비고

