### PR TITLE
[FEAT] createGallery API, 테스트, restdocs 구현

### DIFF
--- a/src/docs/asciidoc/gallery.adoc
+++ b/src/docs/asciidoc/gallery.adoc
@@ -1,0 +1,8 @@
+== 갤러리 API
+:source-highlighter: highlightjs
+
+---
+=== 갤러리 게시글 생성 (POST /galleries)
+====
+operation::gallery-controller-test/create-gallery[snippets="http-request,request-fields,http-response,response-fields"]
+====

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -9,4 +9,4 @@
 
 include::{snippets}/exception-code-controller-test/get-exception-codes/exception-response-fields.adoc[]
 
-// include::eventPeriod.adoc[] 컨트롤러별로 주석 지우고 문서 추가
+include::gallery.adoc[]

--- a/src/main/java/com/scg/stop/domain/file/domain/File.java
+++ b/src/main/java/com/scg/stop/domain/file/domain/File.java
@@ -46,4 +46,8 @@ public class File extends BaseTimeEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "gallery_id")
     private Gallery gallery;
+
+    public void setGallery(Gallery gallery) {
+        this.gallery = gallery;
+    }
 }

--- a/src/main/java/com/scg/stop/domain/file/dto/response/FileResponse.java
+++ b/src/main/java/com/scg/stop/domain/file/dto/response/FileResponse.java
@@ -2,6 +2,7 @@ package com.scg.stop.domain.file.dto.response;
 
 import static lombok.AccessLevel.PRIVATE;
 
+import com.scg.stop.domain.file.domain.File;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,4 +19,15 @@ public class FileResponse {
     private String mimeType;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public static FileResponse from(File file) {
+        return new FileResponse(
+                file.getId(),
+                file.getUuid(),
+                file.getName(),
+                file.getMimeType(),
+                file.getCreatedAt(),
+                file.getUpdatedAt()
+        );
+    }
 }

--- a/src/main/java/com/scg/stop/domain/file/dto/response/FileResponse.java
+++ b/src/main/java/com/scg/stop/domain/file/dto/response/FileResponse.java
@@ -1,7 +1,15 @@
 package com.scg.stop.domain.file.dto.response;
 
-import java.time.LocalDateTime;
+import static lombok.AccessLevel.PRIVATE;
 
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
 public class FileResponse {
 
     private Long id;

--- a/src/main/java/com/scg/stop/domain/file/dto/response/FileResponse.java
+++ b/src/main/java/com/scg/stop/domain/file/dto/response/FileResponse.java
@@ -1,0 +1,13 @@
+package com.scg.stop.domain.file.dto.response;
+
+import java.time.LocalDateTime;
+
+public class FileResponse {
+
+    private Long id;
+    private String uuid;
+    private String name;
+    private String mimeType;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/scg/stop/domain/file/repository/FileRepository.java
+++ b/src/main/java/com/scg/stop/domain/file/repository/FileRepository.java
@@ -1,0 +1,12 @@
+package com.scg.stop.domain.file.repository;
+
+import com.scg.stop.domain.file.domain.File;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FileRepository extends JpaRepository<File, Long> {
+
+    List<File> findByIdIn(List<Long> ids);
+}

--- a/src/main/java/com/scg/stop/domain/gallery/controller/GalleryController.java
+++ b/src/main/java/com/scg/stop/domain/gallery/controller/GalleryController.java
@@ -19,6 +19,7 @@ public class GalleryController {
 
     private final GalleryService galleryService;
 
+    // TODO Auth 설정 추가
     @PostMapping
     public ResponseEntity<GalleryResponse> createGallery(@RequestBody @Valid CreateGalleryRequest createGalleryRequest) {
         GalleryResponse galleryResponse = galleryService.createGallery(createGalleryRequest);

--- a/src/main/java/com/scg/stop/domain/gallery/controller/GalleryController.java
+++ b/src/main/java/com/scg/stop/domain/gallery/controller/GalleryController.java
@@ -1,0 +1,27 @@
+package com.scg.stop.domain.gallery.controller;
+
+import com.scg.stop.domain.gallery.dto.request.CreateGalleryRequest;
+import com.scg.stop.domain.gallery.dto.response.GalleryResponse;
+import com.scg.stop.domain.gallery.service.GalleryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/galleries")
+public class GalleryController {
+
+    private final GalleryService galleryService;
+
+    @PostMapping
+    public ResponseEntity<GalleryResponse> createGallery(@RequestBody @Valid CreateGalleryRequest createGalleryRequest) {
+        GalleryResponse galleryResponse = galleryService.createGallery(createGalleryRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(galleryResponse);
+    }
+}

--- a/src/main/java/com/scg/stop/domain/gallery/domain/Gallery.java
+++ b/src/main/java/com/scg/stop/domain/gallery/domain/Gallery.java
@@ -25,7 +25,6 @@ public class Gallery extends BaseTimeEntity {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-
     @Column(nullable = false)
     private String title;
 

--- a/src/main/java/com/scg/stop/domain/gallery/domain/Gallery.java
+++ b/src/main/java/com/scg/stop/domain/gallery/domain/Gallery.java
@@ -50,13 +50,7 @@ public class Gallery extends BaseTimeEntity {
         files.forEach(file -> file.setGallery(this));
     }
 
-    public static Gallery of(CreateGalleryRequest request, List<File> files) {
-        return new Gallery(
-                request.getTitle(),
-                request.getContent(),
-                request.getYear(),
-                request.getMonth(),
-                files
-        );
+    public static Gallery of(String title, String content, Integer year, Integer month, List<File> files) {
+        return new Gallery(title, content, year, month, files);
     }
 }

--- a/src/main/java/com/scg/stop/domain/gallery/domain/Gallery.java
+++ b/src/main/java/com/scg/stop/domain/gallery/domain/Gallery.java
@@ -5,6 +5,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.scg.stop.domain.file.domain.File;
+import com.scg.stop.domain.gallery.dto.request.CreateGalleryRequest;
 import com.scg.stop.global.domain.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -39,4 +40,23 @@ public class Gallery extends BaseTimeEntity {
 
     @OneToMany(fetch = LAZY, mappedBy = "gallery")
     private List<File> files = new ArrayList<>();
+
+    private Gallery(String title, String content, Integer year, Integer month, List<File> files) {
+        this.title = title;
+        this.content = content;
+        this.year = year;
+        this.month = month;
+        this.files = files;
+        files.forEach(file -> file.setGallery(this));
+    }
+
+    public static Gallery of(CreateGalleryRequest request, List<File> files) {
+        return new Gallery(
+                request.getTitle(),
+                request.getContent(),
+                request.getYear(),
+                request.getMonth(),
+                files
+        );
+    }
 }

--- a/src/main/java/com/scg/stop/domain/gallery/dto/request/CreateGalleryRequest.java
+++ b/src/main/java/com/scg/stop/domain/gallery/dto/request/CreateGalleryRequest.java
@@ -4,12 +4,15 @@ import static lombok.AccessLevel.PRIVATE;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
 public class CreateGalleryRequest {
 
     @NotBlank(message = "제목을 입력해주세요.")
@@ -24,5 +27,7 @@ public class CreateGalleryRequest {
     @NotNull(message = "월을 입력해주세요.")
     private int month;
 
+    @Size(min = 1, message = "1개 이상의 파일을 첨부해야 합니다.")
+    @NotNull(message = "파일을 첨부해주세요.")
     private List<Long> fileIds;
 }

--- a/src/main/java/com/scg/stop/domain/gallery/dto/request/CreateGalleryRequest.java
+++ b/src/main/java/com/scg/stop/domain/gallery/dto/request/CreateGalleryRequest.java
@@ -1,0 +1,28 @@
+package com.scg.stop.domain.gallery.dto.request;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+public class CreateGalleryRequest {
+
+    @NotBlank(message = "제목을 입력해주세요.")
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요.")
+    private String content;
+
+    @NotNull(message = "연도를 입력해주세요.")
+    private int year;
+
+    @NotNull(message = "월을 입력해주세요.")
+    private int month;
+
+    private List<Long> fileIds;
+}

--- a/src/main/java/com/scg/stop/domain/gallery/dto/response/GalleryResponse.java
+++ b/src/main/java/com/scg/stop/domain/gallery/dto/response/GalleryResponse.java
@@ -5,11 +5,13 @@ import static lombok.AccessLevel.PRIVATE;
 import com.scg.stop.domain.file.dto.response.FileResponse;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
 public class GalleryResponse {
 
     private Long id;

--- a/src/main/java/com/scg/stop/domain/gallery/dto/response/GalleryResponse.java
+++ b/src/main/java/com/scg/stop/domain/gallery/dto/response/GalleryResponse.java
@@ -3,6 +3,7 @@ package com.scg.stop.domain.gallery.dto.response;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.scg.stop.domain.file.dto.response.FileResponse;
+import com.scg.stop.domain.gallery.domain.Gallery;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -22,4 +23,17 @@ public class GalleryResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private List<FileResponse> files;
+
+    public static GalleryResponse of(Gallery gallery, List<FileResponse> fileResponses) {
+        return new GalleryResponse(
+                gallery.getId(),
+                gallery.getTitle(),
+                gallery.getContent(),
+                gallery.getYear(),
+                gallery.getMonth(),
+                gallery.getCreatedAt(),
+                gallery.getUpdatedAt(),
+                fileResponses
+        );
+    }
 }

--- a/src/main/java/com/scg/stop/domain/gallery/dto/response/GalleryResponse.java
+++ b/src/main/java/com/scg/stop/domain/gallery/dto/response/GalleryResponse.java
@@ -1,0 +1,23 @@
+package com.scg.stop.domain.gallery.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.scg.stop.domain.file.dto.response.FileResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+public class GalleryResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+    private int year;
+    private int month;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<FileResponse> files;
+}

--- a/src/main/java/com/scg/stop/domain/gallery/repository/GalleryRepository.java
+++ b/src/main/java/com/scg/stop/domain/gallery/repository/GalleryRepository.java
@@ -1,0 +1,9 @@
+package com.scg.stop.domain.gallery.repository;
+
+import com.scg.stop.domain.gallery.domain.Gallery;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GalleryRepository extends JpaRepository<Gallery, Long> {
+}

--- a/src/main/java/com/scg/stop/domain/gallery/service/GalleryService.java
+++ b/src/main/java/com/scg/stop/domain/gallery/service/GalleryService.java
@@ -1,0 +1,19 @@
+package com.scg.stop.domain.gallery.service;
+
+import static org.hamcrest.Matchers.any;
+
+import com.scg.stop.domain.gallery.dto.request.CreateGalleryRequest;
+import com.scg.stop.domain.gallery.dto.response.GalleryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GalleryService {
+
+    public GalleryResponse createGallery(CreateGalleryRequest request) {
+        return (GalleryResponse) any(GalleryResponse.class);
+    }
+}

--- a/src/main/java/com/scg/stop/domain/gallery/service/GalleryService.java
+++ b/src/main/java/com/scg/stop/domain/gallery/service/GalleryService.java
@@ -30,7 +30,7 @@ public class GalleryService {
             throw new BadRequestException(NOT_FOUND_FILE_ID);
         }
 
-        Gallery gallery = Gallery.of(request, files);
+        Gallery gallery = Gallery.of(request.getTitle(), request.getContent(), request.getYear(), request.getMonth(), files);
         Gallery savedGallery = galleryRepository.save(gallery);
 
         List<FileResponse> fileResponses = files.stream()

--- a/src/main/java/com/scg/stop/domain/gallery/service/GalleryService.java
+++ b/src/main/java/com/scg/stop/domain/gallery/service/GalleryService.java
@@ -1,9 +1,17 @@
 package com.scg.stop.domain.gallery.service;
 
-import static org.hamcrest.Matchers.any;
+import static com.scg.stop.global.exception.ExceptionCode.NOT_FOUND_FILE_ID;
 
+import com.scg.stop.domain.file.domain.File;
+import com.scg.stop.domain.file.dto.response.FileResponse;
+import com.scg.stop.domain.file.repository.FileRepository;
+import com.scg.stop.domain.gallery.domain.Gallery;
 import com.scg.stop.domain.gallery.dto.request.CreateGalleryRequest;
 import com.scg.stop.domain.gallery.dto.response.GalleryResponse;
+import com.scg.stop.domain.gallery.repository.GalleryRepository;
+import com.scg.stop.global.exception.BadRequestException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,7 +21,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class GalleryService {
 
+    private final GalleryRepository galleryRepository;
+    private final FileRepository fileRepository;
+
     public GalleryResponse createGallery(CreateGalleryRequest request) {
-        return (GalleryResponse) any(GalleryResponse.class);
+        List<File> files = fileRepository.findByIdIn(request.getFileIds());
+        if (files.size() != request.getFileIds().size()) {
+            throw new BadRequestException(NOT_FOUND_FILE_ID);
+        }
+
+        Gallery gallery = Gallery.of(request, files);
+        Gallery savedGallery = galleryRepository.save(gallery);
+
+        List<FileResponse> fileResponses = files.stream()
+                .map(FileResponse::from)
+                .collect(Collectors.toList());
+        return GalleryResponse.of(savedGallery, fileResponses);
     }
 }

--- a/src/main/java/com/scg/stop/global/exception/ExceptionCode.java
+++ b/src/main/java/com/scg/stop/global/exception/ExceptionCode.java
@@ -9,7 +9,11 @@ public enum ExceptionCode {
 
     INVALID_REQUEST(1000, "요청 형식이 올바르지 않습니다."),
 
-    DUPLICATED_YEAR(1001, "해당 연도의 행사 기간이 이미 존재합니다.");
+    // event
+    DUPLICATED_YEAR(1001, "해당 연도의 행사 기간이 이미 존재합니다."),
+
+    // file
+    NOT_FOUND_FILE_ID(2001, "요청한 ID에 해당하는 파일이 존재하지 않습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,9 +3,9 @@ spring:
     activate:
       on-profile: local
   datasource:
-    url: jdbc:mysql://127.0.0.1:3306/s-top
+    url: jdbc:mysql://127.0.0.1:3307/stop
     username: root
-    password: 0008
+    password: 1234
   jpa:
     open-in-view: false
     show-sql: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,17 +3,21 @@ spring:
     activate:
       on-profile: local
   datasource:
-    url: jdbc:mysql://127.0.0.1:3307/stop
+    url: jdbc:mysql://127.0.0.1:3306/s-top
     username: root
-    password: 1234
+    password: 0008
   jpa:
     open-in-view: false
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
+      format_sql: true
     properties:
       hibernate:
         default_batch_fetch_size: 15
 
+logging.level:
+  org.hibernate.SQL: debug
+  org.hibernate.orm.jdbc.bind: trace #스프링 부트 3.x, hibernate6
 
 server.port: 8000

--- a/src/test/java/com/scg/stop/domain/gallery/controller/GalleryControllerTest.java
+++ b/src/test/java/com/scg/stop/domain/gallery/controller/GalleryControllerTest.java
@@ -1,0 +1,104 @@
+package com.scg.stop.domain.gallery.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scg.stop.configuration.AbstractControllerTest;
+import com.scg.stop.domain.file.dto.response.FileResponse;
+import com.scg.stop.domain.gallery.dto.request.CreateGalleryRequest;
+import com.scg.stop.domain.gallery.dto.response.GalleryResponse;
+import com.scg.stop.domain.gallery.service.GalleryService;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(controllers = GalleryController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+class GalleryControllerTest extends AbstractControllerTest {
+
+    @MockBean
+    private GalleryService galleryService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // TODO Auth 설정 추가
+    @Test
+    @DisplayName("갤러리 게시글을 생성할 수 있다.")
+    void createGallery() throws Exception {
+
+        // given
+        List<Long> fileIds = Arrays.asList(1L, 2L, 3L);
+        List<FileResponse> fileResponses = Arrays.asList(
+                new FileResponse(1L, "014eb8a0-d4a6-11ee-adac-117d766aca1d", "사진1.jpg", "image/jpeg", LocalDateTime.now(), LocalDateTime.now()),
+                new FileResponse(2L, "11a480c0-13fa-11ef-9047-570191b390ea", "사진2.jpg", "image/jpeg", LocalDateTime.now(), LocalDateTime.now()),
+                new FileResponse(3L, "1883fc70-cfb4-11ee-a387-e754bd392d45", "사진3.jpg", "image/jpeg", LocalDateTime.now(), LocalDateTime.now())
+        );
+        CreateGalleryRequest request = new CreateGalleryRequest("새내기 배움터", "2024년 새내기 배움터", 2024, 4, fileIds);
+        GalleryResponse response = new GalleryResponse(
+                1L,
+                "새내기 배움터",
+                "2024년 새내기 배움터",
+                2024,
+                4,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                fileResponses
+        );
+        when(galleryService.createGallery(any(CreateGalleryRequest.class))).thenReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                post("/galleries")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        result.andExpect(status().isCreated())
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                fieldWithPath("year").type(JsonFieldType.NUMBER).description("연도"),
+                                fieldWithPath("month").type(JsonFieldType.NUMBER).description("월"),
+                                fieldWithPath("fileIds").type(JsonFieldType.ARRAY).description("파일 ID 리스트")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("갤러리 ID"),
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                fieldWithPath("year").type(JsonFieldType.NUMBER).description("연도"),
+                                fieldWithPath("month").type(JsonFieldType.NUMBER).description("월"),
+                                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성일"),
+                                fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("수정일"),
+                                fieldWithPath("files").type(JsonFieldType.ARRAY).description("파일 목록"),
+                                fieldWithPath("files[].id").type(JsonFieldType.NUMBER).description("파일 ID"),
+                                fieldWithPath("files[].uuid").type(JsonFieldType.STRING).description("파일 UUID"),
+                                fieldWithPath("files[].name").type(JsonFieldType.STRING).description("파일 이름"),
+                                fieldWithPath("files[].mimeType").type(JsonFieldType.STRING).description("파일 MIME 타입"),
+                                fieldWithPath("files[].createdAt").type(JsonFieldType.STRING).description("파일 생성일"),
+                                fieldWithPath("files[].updatedAt").type(JsonFieldType.STRING).description("파일 수정일")
+                        )
+                ));
+    }
+}


### PR DESCRIPTION
작성자: @yesjuhee 

- 연관 이슈 : #10 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- createGallery API 구현 완료했습니다.
- 빌드/실행 후 `localhost:8000/docs/index.html`에서 restdocs 확인할 수 있습니다

## 비고

- `file` 도메인 아래에 작성한 코드들 가져가서 사용하시면 됩니다!!
- 해당 내용 바탕으로 나머지 API 작성 부탁드립니다 🙇 @simta1 
