### PR TITLE
[FEAT] getGalleries API, restdocs 구현

### DIFF
--- a/src/docs/asciidoc/gallery.adoc
+++ b/src/docs/asciidoc/gallery.adoc
@@ -6,3 +6,8 @@
 ====
 operation::gallery-controller-test/create-gallery[snippets="http-request,request-fields,http-response,response-fields"]
 ====
+
+=== 갤러리 게시글 목록 조회 (GET /galleries)
+====
+operation::gallery-controller-test/get-galleries[snippets="http-request,query-parameters,http-response,response-fields"]
+====

--- a/src/main/java/com/scg/stop/domain/gallery/controller/GalleryController.java
+++ b/src/main/java/com/scg/stop/domain/gallery/controller/GalleryController.java
@@ -5,12 +5,13 @@ import com.scg.stop.domain.gallery.dto.response.GalleryResponse;
 import com.scg.stop.domain.gallery.service.GalleryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +25,14 @@ public class GalleryController {
     public ResponseEntity<GalleryResponse> createGallery(@RequestBody @Valid CreateGalleryRequest createGalleryRequest) {
         GalleryResponse galleryResponse = galleryService.createGallery(createGalleryRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(galleryResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<GalleryResponse>> getGalleries(
+            @RequestParam(value = "year", required = false) Integer year,
+            @RequestParam(value = "month", required = false) Integer month,
+            @PageableDefault(page = 0, size = 10) Pageable pageable) {
+        Page<GalleryResponse> galleries = galleryService.getGalleries(year, month, pageable);
+        return ResponseEntity.ok(galleries);
     }
 }

--- a/src/main/java/com/scg/stop/domain/gallery/repository/GalleryRepository.java
+++ b/src/main/java/com/scg/stop/domain/gallery/repository/GalleryRepository.java
@@ -1,9 +1,24 @@
 package com.scg.stop.domain.gallery.repository;
 
 import com.scg.stop.domain.gallery.domain.Gallery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface GalleryRepository extends JpaRepository<Gallery, Long> {
+
+    @Query("SELECT g FROM Gallery g " +
+            "WHERE (:year IS NULL OR g.year = :year) " +
+            "AND (:month IS NULL OR g.month = :month)")
+    Page<Gallery> findGalleries(
+            @Param("year") Integer year,
+            @Param("month") Integer month,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/scg/stop/domain/gallery/service/GalleryService.java
+++ b/src/main/java/com/scg/stop/domain/gallery/service/GalleryService.java
@@ -13,6 +13,8 @@ import com.scg.stop.global.exception.BadRequestException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,5 +39,17 @@ public class GalleryService {
                 .map(FileResponse::from)
                 .collect(Collectors.toList());
         return GalleryResponse.of(savedGallery, fileResponses);
+    }
+
+    public Page<GalleryResponse> getGalleries(Integer year, Integer month, Pageable pageable) {
+        Page<Gallery> galleries = galleryRepository.findGalleries(year, month, pageable);
+        return galleries.map(this::entityToGalleryResponse);
+    }
+
+    private GalleryResponse entityToGalleryResponse(Gallery gallery) {
+        List<FileResponse> fileResponses = gallery.getFiles().stream()
+                .map(FileResponse::from)
+                .collect(Collectors.toList());
+        return GalleryResponse.of(gallery, fileResponses);
     }
 }

--- a/src/main/java/com/scg/stop/domain/gallery/service/GalleryService.java
+++ b/src/main/java/com/scg/stop/domain/gallery/service/GalleryService.java
@@ -20,12 +20,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class GalleryService {
 
     private final GalleryRepository galleryRepository;
     private final FileRepository fileRepository;
 
+    @Transactional
     public GalleryResponse createGallery(CreateGalleryRequest request) {
         List<File> files = fileRepository.findByIdIn(request.getFileIds());
         if (files.size() != request.getFileIds().size()) {
@@ -41,6 +41,7 @@ public class GalleryService {
         return GalleryResponse.of(savedGallery, fileResponses);
     }
 
+    @Transactional(readOnly = true)
     public Page<GalleryResponse> getGalleries(Integer year, Integer month, Pageable pageable) {
         Page<Gallery> galleries = galleryRepository.findGalleries(year, month, pageable);
         return galleries.map(this::entityToGalleryResponse);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,9 +3,9 @@ spring:
     activate:
       on-profile: local
   datasource:
-    url: jdbc:mysql://127.0.0.1:3306/s-top
+    url: jdbc:mysql://127.0.0.1:3307/stop
     username: root
-    password: 0008
+    password: 1234
   jpa:
     open-in-view: false
     show-sql: true

--- a/src/test/java/com/scg/stop/domain/gallery/controller/GalleryControllerTest.java
+++ b/src/test/java/com/scg/stop/domain/gallery/controller/GalleryControllerTest.java
@@ -144,7 +144,9 @@ class GalleryControllerTest extends AbstractControllerTest {
                 .andDo(restDocs.document(
                         queryParameters(
                                 parameterWithName("year").optional().description("연도"),
-                                parameterWithName("month").optional().description("월")
+                                parameterWithName("month").optional().description("월"),
+                                parameterWithName("page").optional().description("페이지 번호 [default: 0]"),
+                                parameterWithName("size").optional().description("페이지 크기 [default: 10]")
                         ),
                         responseFields(
                                 fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("전체 데이터 수"),
@@ -166,7 +168,6 @@ class GalleryControllerTest extends AbstractControllerTest {
                                 fieldWithPath("content[].files[].createdAt").type(JsonFieldType.STRING).description("파일 생성일"),
                                 fieldWithPath("content[].files[].updatedAt").type(JsonFieldType.STRING).description("파일 수정일"),
                                 fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
-//                                fieldWithPath("sort").ignored(),
                                 fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 정보"),
                                 fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬 정보"),
                                 fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬 정보"),

--- a/src/test/java/com/scg/stop/domain/gallery/controller/GalleryControllerTest.java
+++ b/src/test/java/com/scg/stop/domain/gallery/controller/GalleryControllerTest.java
@@ -10,8 +10,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/com/scg/stop/domain/gallery/controller/GalleryControllerTest.java
+++ b/src/test/java/com/scg/stop/domain/gallery/controller/GalleryControllerTest.java
@@ -2,11 +2,15 @@ package com.scg.stop.domain.gallery.controller;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -19,6 +23,7 @@ import com.scg.stop.domain.gallery.service.GalleryService;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +31,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -98,6 +105,77 @@ class GalleryControllerTest extends AbstractControllerTest {
                                 fieldWithPath("files[].mimeType").type(JsonFieldType.STRING).description("파일 MIME 타입"),
                                 fieldWithPath("files[].createdAt").type(JsonFieldType.STRING).description("파일 생성일"),
                                 fieldWithPath("files[].updatedAt").type(JsonFieldType.STRING).description("파일 수정일")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("갤러리 게시글 목록을 조회할 수 있다.")
+    void getGalleries() throws Exception {
+
+        // given
+        List<FileResponse> fileResponses = Arrays.asList(
+                new FileResponse(1L, "014eb8a0-d4a6-11ee-adac-117d766aca1d", "사진1.jpg", "image/jpeg", LocalDateTime.now(), LocalDateTime.now()),
+                new FileResponse(2L, "11a480c0-13fa-11ef-9047-570191b390ea", "사진2.jpg", "image/jpeg", LocalDateTime.now(), LocalDateTime.now()),
+                new FileResponse(3L, "1883fc70-cfb4-11ee-a387-e754bd392d45", "사진3.jpg", "image/jpeg", LocalDateTime.now(), LocalDateTime.now())
+        );
+        GalleryResponse galleryResponse = new GalleryResponse(
+                1L,
+                "새내기 배움터",
+                "2024년 새내기 배움터",
+                2024,
+                4,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                fileResponses
+        );
+        PageImpl<GalleryResponse> galleryResponses = new PageImpl<>(Collections.singletonList(galleryResponse));
+        when(galleryService.getGalleries(anyInt(), anyInt(), any(Pageable.class))).thenReturn(galleryResponses);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/galleries")
+                        .param("year", "2024")
+                        .param("month", "4")
+                        .contentType(APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        queryParameters(
+                                parameterWithName("year").optional().description("연도"),
+                                parameterWithName("month").optional().description("월")
+                        ),
+                        responseFields(
+                                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("전체 데이터 수"),
+                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 수"),
+                                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지당 데이터 수"),
+                                fieldWithPath("content").type(JsonFieldType.ARRAY).description("갤러리 목록"),
+                                fieldWithPath("content[].id").type(JsonFieldType.NUMBER).description("갤러리 ID"),
+                                fieldWithPath("content[].title").type(JsonFieldType.STRING).description("갤러리 제목"),
+                                fieldWithPath("content[].content").type(JsonFieldType.STRING).description("갤러리 내용"),
+                                fieldWithPath("content[].year").type(JsonFieldType.NUMBER).description("갤러리 연도"),
+                                fieldWithPath("content[].month").type(JsonFieldType.NUMBER).description("갤러리 월"),
+                                fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("갤러리 생성일"),
+                                fieldWithPath("content[].updatedAt").type(JsonFieldType.STRING).description("갤러리 수정일"),
+                                fieldWithPath("content[].files").type(JsonFieldType.ARRAY).description("파일 목록"),
+                                fieldWithPath("content[].files[].id").type(JsonFieldType.NUMBER).description("파일 ID"),
+                                fieldWithPath("content[].files[].uuid").type(JsonFieldType.STRING).description("파일 UUID"),
+                                fieldWithPath("content[].files[].name").type(JsonFieldType.STRING).description("파일 이름"),
+                                fieldWithPath("content[].files[].mimeType").type(JsonFieldType.STRING).description("파일 MIME 타입"),
+                                fieldWithPath("content[].files[].createdAt").type(JsonFieldType.STRING).description("파일 생성일"),
+                                fieldWithPath("content[].files[].updatedAt").type(JsonFieldType.STRING).description("파일 수정일"),
+                                fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+//                                fieldWithPath("sort").ignored(),
+                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 정보"),
+                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬 정보"),
+                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬 정보"),
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 데이터 수"),
+                                fieldWithPath("pageable").ignored(),
+                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("빈 페이지 여부")
                         )
                 ));
     }


### PR DESCRIPTION
작성자: @simta1 

#10 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- getGalleries API 구현했습니다.
- 테스트는 어떤 걸 테스트해야 될지 모르겠어서 일단 restdocs만이라도 나오게 했습니다
- 빌드/실행 후 localhost:8000/docs/index.html에서 확인할 수 있습니다

## 비고

- 🙇🙇🙇🙇🙇🙇🙇
