### PR TITLE
[Feat] createProject, getProject, updateProject, deleteProject API, restdocs 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -5,8 +5,4 @@
 :toclevels: 3
 :seclinks:
 
-=== 커스텀 예외 코드
-
-include::{snippets}/exception-code-controller-test/get-exception-codes/exception-response-fields.adoc[]
-
-// include::eventPeriod.adoc[] 컨트롤러별로 주석 지우고 문서 추가
+include::project.adoc[]

--- a/src/docs/asciidoc/project.adoc
+++ b/src/docs/asciidoc/project.adoc
@@ -1,0 +1,32 @@
+== 프로젝트 API
+:source-highlighter: highlightjs
+
+---
+=== 공지 사항 생성 (POST /notices)
+==== 201 Created
+====
+operation::project-controller-test/create-project[snippets="http-request,request-fields,http-response,response-fields"]
+====
+
+
+---
+=== 공지 사항 조회 (GET /notices/{noticeId})
+==== 200 OK
+====
+operation::project-controller-test/get-project[snippets="path-parameters,http-request,http-response,response-fields"]
+====
+
+
+---
+=== 공지 사항 수정 (PUT /notices/{noticeId})
+==== 200 OK
+====
+operation::project-controller-test/update-project[snippets="path-parameters,http-request,request-fields,http-response,response-fields"]
+====
+
+---
+=== 공지 사항 삭제 (DELETE /notices/{noticeId})
+==== 204 No Content
+====
+operation::project-controller-test/delete-project[snippets="path-parameters,http-request,http-response"]
+====

--- a/src/main/java/com/scg/stop/domain/file/repository/FileRepository.java
+++ b/src/main/java/com/scg/stop/domain/file/repository/FileRepository.java
@@ -1,0 +1,10 @@
+package com.scg.stop.domain.file.repository;
+
+import com.scg.stop.domain.file.domain.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+    Optional<File> findById(Long id);
+}

--- a/src/main/java/com/scg/stop/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/scg/stop/domain/project/controller/ProjectController.java
@@ -26,7 +26,7 @@ public class ProjectController {
 
     @GetMapping("/{projectId}")
     public ResponseEntity<ProjectDetailResponse> getProject(
-            @PathVariable Long projectId
+            @PathVariable("projectId") Long projectId
     ) {
         ProjectDetailResponse projectDetailResponse = projectService.getProject(projectId);
         return ResponseEntity.status(HttpStatus.OK).body(projectDetailResponse);
@@ -34,7 +34,7 @@ public class ProjectController {
 
     @PutMapping("/{projectId}")
     public ResponseEntity<ProjectDetailResponse> updateProject(
-            @PathVariable Long projectId,
+            @PathVariable("projectId") Long projectId,
             @RequestBody @Valid ProjectRequest projectRequest
     ) {
         ProjectDetailResponse projectDetailResponse = projectService.updateProject(projectId, projectRequest);
@@ -43,7 +43,7 @@ public class ProjectController {
 
     @DeleteMapping("/{projectId}")
     public ResponseEntity<Void> deleteProject(
-            @PathVariable Long projectId
+            @PathVariable("projectId") Long projectId
     ) {
         projectService.deleteProject(projectId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/scg/stop/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/scg/stop/domain/project/controller/ProjectController.java
@@ -1,0 +1,17 @@
+package com.scg.stop.domain.project.controller;
+
+import com.scg.stop.domain.project.service.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+}

--- a/src/main/java/com/scg/stop/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/scg/stop/domain/project/controller/ProjectController.java
@@ -1,14 +1,13 @@
 package com.scg.stop.domain.project.controller;
 
 import com.scg.stop.domain.project.dto.request.ProjectRequest;
+import com.scg.stop.domain.project.dto.response.ProjectDetailResponse;
 import com.scg.stop.domain.project.service.ProjectService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,12 +17,35 @@ public class ProjectController {
     private final ProjectService projectService;
 
     @PostMapping
-    public ResponseEntity<Void> createProject(
+    public ResponseEntity<ProjectDetailResponse> createProject(
             @RequestBody @Valid ProjectRequest projectRequest
     ) {
-        projectService.createProject(projectRequest);
-        return ResponseEntity.ok().build();
+        ProjectDetailResponse projectDetailResponse = projectService.createProject(projectRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(projectDetailResponse);
     }
 
+    @GetMapping("/{projectId}")
+    public ResponseEntity<ProjectDetailResponse> getProject(
+            @PathVariable Long projectId
+    ) {
+        ProjectDetailResponse projectDetailResponse = projectService.getProject(projectId);
+        return ResponseEntity.status(HttpStatus.OK).body(projectDetailResponse);
+    }
 
+    @PutMapping("/{projectId}")
+    public ResponseEntity<ProjectDetailResponse> updateProject(
+            @PathVariable Long projectId,
+            @RequestBody @Valid ProjectRequest projectRequest
+    ) {
+        ProjectDetailResponse projectDetailResponse = projectService.updateProject(projectId, projectRequest);
+        return ResponseEntity.status(HttpStatus.OK).body(projectDetailResponse);
+    }
+
+    @DeleteMapping("/{projectId}")
+    public ResponseEntity<Void> deleteProject(
+            @PathVariable Long projectId
+    ) {
+        projectService.deleteProject(projectId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/scg/stop/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/scg/stop/domain/project/controller/ProjectController.java
@@ -1,9 +1,12 @@
 package com.scg.stop.domain.project.controller;
 
+import com.scg.stop.domain.project.dto.request.ProjectRequest;
 import com.scg.stop.domain.project.service.ProjectService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,5 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProjectController {
 
     private final ProjectService projectService;
+
+    @PostMapping
+    public ResponseEntity<Void> createProject(
+            @RequestBody @Valid ProjectRequest projectRequest
+    ) {
+        projectService.createProject(projectRequest);
+        return ResponseEntity.ok().build();
+    }
+
 
 }

--- a/src/main/java/com/scg/stop/domain/project/domain/Member.java
+++ b/src/main/java/com/scg/stop/domain/project/domain/Member.java
@@ -13,12 +13,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
 public class Member extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/scg/stop/domain/project/domain/Project.java
+++ b/src/main/java/com/scg/stop/domain/project/domain/Project.java
@@ -64,15 +64,29 @@ public class Project extends BaseTimeEntity {
     @OneToMany(fetch = LAZY, mappedBy = "project", cascade = CascadeType.ALL)
     private List<Member> members = new ArrayList<>();
 
-    @OneToMany(fetch = LAZY, mappedBy = "project")
+    @OneToMany(fetch = LAZY, mappedBy = "project", cascade = CascadeType.REMOVE)
     private List<Likes> likes = new ArrayList<>();
 
-    @OneToMany(fetch = LAZY, mappedBy = "project")
+    @OneToMany(fetch = LAZY, mappedBy = "project", cascade = CascadeType.REMOVE)
     private List<FavoriteProject> favorites = new ArrayList<>();
 
-    @OneToMany(fetch = LAZY, mappedBy = "project")
+    @OneToMany(fetch = LAZY, mappedBy = "project", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(fetch = LAZY, mappedBy = "project")
+    @OneToMany(fetch = LAZY, mappedBy = "project", cascade = CascadeType.REMOVE)
     private List<Inquiry> inquiries = new ArrayList<>();
+
+    public void update(Project project) {
+        this.name = project.getName();
+        this.type = project.getType();
+        this.category = project.getCategory();
+        this.team = project.getTeam();
+        this.youtubeId = project.getYoutubeId();
+        this.techStack = project.getTechStack();
+        this.year = project.getYear();
+        this.awardStatus = project.getAwardStatus();
+        this.thumbnail = project.getThumbnail();
+        this.poster = project.getPoster();
+        this.members = project.getMembers();
+    }
 }

--- a/src/main/java/com/scg/stop/domain/project/domain/Project.java
+++ b/src/main/java/com/scg/stop/domain/project/domain/Project.java
@@ -53,11 +53,11 @@ public class Project extends BaseTimeEntity {
     @Enumerated(value = STRING)
     private AwardStatus awardStatus = AwardStatus.NONE;
 
-    @OneToOne(fetch = LAZY)
+    @OneToOne(fetch = LAZY, orphanRemoval = true)
     @JoinColumn(name = "thumbnail_id")
     private File thumbnail;
 
-    @OneToOne(fetch = LAZY)
+    @OneToOne(fetch = LAZY, orphanRemoval = true)
     @JoinColumn(name = "poster_id")
     private File poster;
 

--- a/src/main/java/com/scg/stop/domain/project/domain/Project.java
+++ b/src/main/java/com/scg/stop/domain/project/domain/Project.java
@@ -7,22 +7,19 @@ import static lombok.AccessLevel.PROTECTED;
 
 import com.scg.stop.domain.file.domain.File;
 import com.scg.stop.global.domain.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
 public class Project extends BaseTimeEntity {
 
     @Id
@@ -64,7 +61,7 @@ public class Project extends BaseTimeEntity {
     @JoinColumn(name = "poster_id")
     private File poster;
 
-    @OneToMany(fetch = LAZY, mappedBy = "project")
+    @OneToMany(fetch = LAZY, mappedBy = "project", cascade = CascadeType.ALL)
     private List<Member> members = new ArrayList<>();
 
     @OneToMany(fetch = LAZY, mappedBy = "project")

--- a/src/main/java/com/scg/stop/domain/project/dto/request/MemberRequest.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/request/MemberRequest.java
@@ -1,0 +1,25 @@
+package com.scg.stop.domain.project.dto.request;
+
+import com.scg.stop.domain.project.domain.Member;
+import com.scg.stop.domain.project.domain.Project;
+import com.scg.stop.domain.project.domain.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberRequest {
+    private String name;
+    private Role role;
+
+    public Member toEntity(Project project) {
+        return new Member(
+                null,
+                name,
+                role,
+                project
+        );
+    }
+}

--- a/src/main/java/com/scg/stop/domain/project/dto/request/MemberRequest.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/request/MemberRequest.java
@@ -15,7 +15,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
 public class MemberRequest {
+
+    @NotBlank(message = "멤버 이름을 입력해주세요")
     private String name;
+
+    @NotNull(message = "멤버 역할을 입력해주세요")
     private Role role;
 
     public Member toEntity(Project project) {
@@ -25,10 +29,5 @@ public class MemberRequest {
                 role,
                 project
         );
-    }
-
-    // members.stream().allMatch(MemberRequest::validate); 이 코드를 사용가능하게 작성해봐
-    public static boolean validate(MemberRequest memberRequest) {
-        return memberRequest.getName() != null && !memberRequest.getName().isBlank() && memberRequest.getRole() != null;
     }
 }

--- a/src/main/java/com/scg/stop/domain/project/dto/request/MemberRequest.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/request/MemberRequest.java
@@ -5,6 +5,8 @@ import static lombok.AccessLevel.PROTECTED;
 import com.scg.stop.domain.project.domain.Member;
 import com.scg.stop.domain.project.domain.Project;
 import com.scg.stop.domain.project.domain.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +15,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
 public class MemberRequest {
-
     private String name;
     private Role role;
 
@@ -24,5 +25,10 @@ public class MemberRequest {
                 role,
                 project
         );
+    }
+
+    // members.stream().allMatch(MemberRequest::validate); 이 코드를 사용가능하게 작성해봐
+    public static boolean validate(MemberRequest memberRequest) {
+        return memberRequest.getName() != null && !memberRequest.getName().isBlank() && memberRequest.getRole() != null;
     }
 }

--- a/src/main/java/com/scg/stop/domain/project/dto/request/MemberRequest.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/request/MemberRequest.java
@@ -1,5 +1,7 @@
 package com.scg.stop.domain.project.dto.request;
 
+import static lombok.AccessLevel.PROTECTED;
+
 import com.scg.stop.domain.project.domain.Member;
 import com.scg.stop.domain.project.domain.Project;
 import com.scg.stop.domain.project.domain.Role;
@@ -9,8 +11,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 public class MemberRequest {
+
     private String name;
     private Role role;
 

--- a/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
@@ -1,4 +1,80 @@
 package com.scg.stop.domain.project.dto.request;
 
+import com.scg.stop.domain.file.domain.File;
+import com.scg.stop.domain.project.domain.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ProjectRequest {
+
+    @NotNull(message = "썸네일 ID를 입력해주세요")
+    private Long thumbnailId;
+
+    @NotNull(message = "포스터 ID를 입력해주세요")
+    private Long posterId;
+
+    @NotBlank(message = "프로젝트 이름을 입력해주세요")
+    private String projectName;
+
+    @NotNull(message = "프로젝트 타입을 입력해주세요")
+    private ProjectType projectType;
+
+    @NotNull(message = "프로젝트 카테고리를 입력해주세요")
+    private ProjectCategory projectCategory;
+
+    @NotBlank(message = "팀 이름을 입력해주세요")
+    private String teamName;
+
+    @NotBlank(message = "프로젝트 yotubeId를 입력해주세요")
+    private String youtubeId;
+
+    @NotBlank(message = "기술 스택을 입력해주세요")
+    private String techStack; // ,로 구분
+
+    @NotNull(message = "프로젝트 년도를 입력해주세요")
+    private Integer year;
+
+    @NotNull(message = "수상 여부를 입력해주세요")
+    private AwardStatus awardStatus;
+
+    @NotNull(message = "멤버를 입력해주세요")
+    private List<MemberRequest> members;
+
+    public Project toEntity(File thumbnail, File poster) {
+        Project project =  new Project(
+                null,
+                projectName,
+                projectType,
+                projectCategory,
+                teamName,
+                youtubeId,
+                techStack,
+                year,
+                awardStatus,
+                thumbnail,
+                poster,
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>()
+        );
+
+        List<Member> memberEntities = members.stream()
+                .map(memberRequest -> memberRequest.toEntity(project))
+                .toList();
+
+        project.getMembers().addAll(memberEntities);
+
+        return project;
+    }
 }

--- a/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
@@ -6,6 +6,7 @@ import com.scg.stop.domain.file.domain.File;
 import com.scg.stop.domain.project.domain.*;
 import com.scg.stop.global.exception.BadRequestException;
 import com.scg.stop.global.exception.ExceptionCode;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -48,6 +49,7 @@ public class ProjectRequest {
     @NotNull(message = "수상 여부를 입력해주세요")
     private final AwardStatus awardStatus;
 
+    @Valid
     @NotNull(message = "멤버를 입력해주세요")
     private final List<MemberRequest> members;
 
@@ -64,7 +66,7 @@ public class ProjectRequest {
             AwardStatus awardStatus,
             List<MemberRequest> members
     ) {
-        validateMembers(members); // 요청받은 멤버들이 모두 유효한지 검증
+
         validateTechStack(techStack); // 요청받은 기술 스택이 유효한지 검증
 
         this.thumbnailId = thumbnailId;
@@ -107,12 +109,6 @@ public class ProjectRequest {
         project.getMembers().addAll(memberEntities);
 
         return project;
-    }
-
-    private void validateMembers(List<MemberRequest> members) {
-        if (!members.stream().allMatch(MemberRequest::validate)) {
-            throw new BadRequestException(ExceptionCode.INVALID_MEMBER);
-        }
     }
 
     private void validateTechStack(String techStack) {

--- a/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
@@ -1,5 +1,7 @@
 package com.scg.stop.domain.project.dto.request;
 
+import static lombok.AccessLevel.PROTECTED;
+
 import com.scg.stop.domain.file.domain.File;
 import com.scg.stop.domain.project.domain.*;
 import jakarta.validation.constraints.NotBlank;
@@ -13,7 +15,7 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 public class ProjectRequest {
 
     @NotNull(message = "썸네일 ID를 입력해주세요")
@@ -49,9 +51,9 @@ public class ProjectRequest {
     @NotNull(message = "멤버를 입력해주세요")
     private List<MemberRequest> members;
 
-    public Project toEntity(File thumbnail, File poster) {
+    public Project toEntity(Long id, File thumbnail, File poster) {
         Project project =  new Project(
-                null,
+                id,
                 projectName,
                 projectType,
                 projectCategory,

--- a/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
@@ -4,6 +4,8 @@ import static lombok.AccessLevel.PROTECTED;
 
 import com.scg.stop.domain.file.domain.File;
 import com.scg.stop.domain.project.domain.*;
+import com.scg.stop.global.exception.BadRequestException;
+import com.scg.stop.global.exception.ExceptionCode;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -52,6 +54,8 @@ public class ProjectRequest {
     private List<MemberRequest> members;
 
     public Project toEntity(Long id, File thumbnail, File poster) {
+        validateMembers(); // 요청받은 멤버들이 모두 유효한지 검증
+
         Project project =  new Project(
                 id,
                 projectName,
@@ -78,5 +82,11 @@ public class ProjectRequest {
         project.getMembers().addAll(memberEntities);
 
         return project;
+    }
+
+    private void validateMembers() {
+        if (!members.stream().allMatch(MemberRequest::validate)) {
+            throw new BadRequestException(ExceptionCode.INVALID_MEMBER);
+        }
     }
 }

--- a/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
@@ -16,46 +16,71 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor(access = PROTECTED)
 public class ProjectRequest {
 
     @NotNull(message = "썸네일 ID를 입력해주세요")
-    private Long thumbnailId;
+    private final Long thumbnailId;
 
     @NotNull(message = "포스터 ID를 입력해주세요")
-    private Long posterId;
+    private final Long posterId;
 
     @NotBlank(message = "프로젝트 이름을 입력해주세요")
-    private String projectName;
+    private final String projectName;
 
     @NotNull(message = "프로젝트 타입을 입력해주세요")
-    private ProjectType projectType;
+    private final ProjectType projectType;
 
     @NotNull(message = "프로젝트 카테고리를 입력해주세요")
-    private ProjectCategory projectCategory;
+    private final ProjectCategory projectCategory;
 
     @NotBlank(message = "팀 이름을 입력해주세요")
-    private String teamName;
+    private final String teamName;
 
     @NotBlank(message = "프로젝트 yotubeId를 입력해주세요")
-    private String youtubeId;
+    private final String youtubeId;
 
     @NotBlank(message = "기술 스택을 입력해주세요")
-    private String techStack; // ,로 구분
+    private final String techStack; // ,로 구분
 
     @NotNull(message = "프로젝트 년도를 입력해주세요")
-    private Integer year;
+    private final Integer year;
 
     @NotNull(message = "수상 여부를 입력해주세요")
-    private AwardStatus awardStatus;
+    private final AwardStatus awardStatus;
 
     @NotNull(message = "멤버를 입력해주세요")
-    private List<MemberRequest> members;
+    private final List<MemberRequest> members;
+
+    public ProjectRequest(
+            Long thumbnailId,
+            Long posterId,
+            String projectName,
+            ProjectType projectType,
+            ProjectCategory projectCategory,
+            String teamName,
+            String youtubeId,
+            String techStack,
+            Integer year,
+            AwardStatus awardStatus,
+            List<MemberRequest> members
+    ) {
+        validateMembers(members); // 요청받은 멤버들이 모두 유효한지 검증
+        validateTechStack(techStack); // 요청받은 기술 스택이 유효한지 검증
+
+        this.thumbnailId = thumbnailId;
+        this.posterId = posterId;
+        this.projectName = projectName;
+        this.projectType = projectType;
+        this.projectCategory = projectCategory;
+        this.teamName = teamName;
+        this.youtubeId = youtubeId;
+        this.techStack = techStack;
+        this.year = year;
+        this.awardStatus = awardStatus;
+        this.members = members;
+    }
 
     public Project toEntity(Long id, File thumbnail, File poster) {
-        validateMembers(); // 요청받은 멤버들이 모두 유효한지 검증
-
         Project project =  new Project(
                 id,
                 projectName,
@@ -84,9 +109,18 @@ public class ProjectRequest {
         return project;
     }
 
-    private void validateMembers() {
+    private void validateMembers(List<MemberRequest> members) {
         if (!members.stream().allMatch(MemberRequest::validate)) {
             throw new BadRequestException(ExceptionCode.INVALID_MEMBER);
+        }
+    }
+
+    private void validateTechStack(String techStack) {
+        // ', '으로 구분되어서 문자열이 구성이 되어있는지 확인하는 정규표현식
+        String TECH_STACK_PATTERN = "^([\\w가-힣]+)(, [\\w가-힣]+)*$";
+
+        if (!techStack.matches(TECH_STACK_PATTERN)) {
+            throw new BadRequestException(ExceptionCode.INVALID_TECHSTACK);
         }
     }
 }

--- a/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/request/ProjectRequest.java
@@ -1,0 +1,4 @@
+package com.scg.stop.domain.project.dto.request;
+
+public class ProjectRequest {
+}

--- a/src/main/java/com/scg/stop/domain/project/dto/response/ProjectDetailResponse.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/response/ProjectDetailResponse.java
@@ -1,0 +1,55 @@
+package com.scg.stop.domain.project.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.scg.stop.domain.file.domain.File;
+import com.scg.stop.domain.project.domain.AwardStatus;
+import com.scg.stop.domain.project.domain.Project;
+import com.scg.stop.domain.project.domain.ProjectCategory;
+import com.scg.stop.domain.project.domain.ProjectType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ProjectDetailResponse {
+
+    private Long id;
+    private File thumbnailInfo;
+    private File posterInfo;
+    private String projectName;
+    private ProjectType projectType;
+    private ProjectCategory projectCategory;
+    private String teamName;
+    private String youtubeId;
+    private List<String> techStack;
+    private int year;
+    private AwardStatus awardStatus;
+    private List<String> sutudentNames;
+    private List<String> professorNames;
+    private int likeCount;
+    private boolean bookMark;
+
+    public static ProjectDetailResponse of(List<String> sutudentNames, List<String> professorNames, Project project){
+        return new ProjectDetailResponse(
+                project.getId(),
+                project.getThumbnail(),
+                project.getPoster(),
+                project.getName(),
+                project.getType(),
+                project.getCategory(),
+                project.getTeam(),
+                project.getYoutubeId(),
+                List.of(project.getTechStack().split(",")),
+                project.getYear(),
+                project.getAwardStatus(),
+                sutudentNames,
+                professorNames,
+                project.getLikes().size(),
+                !project.getFavorites().isEmpty()
+        );
+    }
+}

--- a/src/main/java/com/scg/stop/domain/project/dto/response/ProjectDetailResponse.java
+++ b/src/main/java/com/scg/stop/domain/project/dto/response/ProjectDetailResponse.java
@@ -49,7 +49,7 @@ public class ProjectDetailResponse {
                 sutudentNames,
                 professorNames,
                 project.getLikes().size(),
-                !project.getFavorites().isEmpty()
+                !project.getFavorites().isEmpty() // ToDo: 인증 설정 추가할 때, 인증된 사용자의 즐겨찾기 여부 확인 로직으로 변경
         );
     }
 }

--- a/src/main/java/com/scg/stop/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/scg/stop/domain/project/repository/ProjectRepository.java
@@ -1,0 +1,8 @@
+package com.scg.stop.domain.project.repository;
+
+import com.scg.stop.domain.project.domain.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+}

--- a/src/main/java/com/scg/stop/domain/project/service/ProjectService.java
+++ b/src/main/java/com/scg/stop/domain/project/service/ProjectService.java
@@ -1,13 +1,29 @@
 package com.scg.stop.domain.project.service;
 
+import com.scg.stop.domain.file.domain.File;
+import com.scg.stop.domain.file.repository.FileRepository;
+import com.scg.stop.domain.project.domain.Project;
+import com.scg.stop.domain.project.dto.request.ProjectRequest;
 import com.scg.stop.domain.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ProjectService {
     private final ProjectRepository projectRepository;
+    private final FileRepository fileRepository;
+    @Transactional
+    public void createProject(ProjectRequest projectRequest) {
+        File thumbnail = fileRepository.findById(projectRequest.getThumbnailId())
+                .orElseThrow(() -> new IllegalArgumentException("썸네일을 찾을 수 없습니다"));
+        File poster = fileRepository.findById(projectRequest.getPosterId())
+                .orElseThrow(() -> new IllegalArgumentException("포스터를 찾을 수 없습니다"));
 
+        // ToDo: BadRequestException dev 브랜치에 있을듯..
+        Project project = projectRequest.toEntity(thumbnail, poster);
 
+        projectRepository.save(project);
+    }
 }

--- a/src/main/java/com/scg/stop/domain/project/service/ProjectService.java
+++ b/src/main/java/com/scg/stop/domain/project/service/ProjectService.java
@@ -1,0 +1,13 @@
+package com.scg.stop.domain.project.service;
+
+import com.scg.stop.domain.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectService {
+    private final ProjectRepository projectRepository;
+
+
+}

--- a/src/main/java/com/scg/stop/domain/project/service/ProjectService.java
+++ b/src/main/java/com/scg/stop/domain/project/service/ProjectService.java
@@ -18,11 +18,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ProjectService {
     private final ProjectRepository projectRepository;
     private final FileRepository fileRepository;
-    @Transactional
+
     public ProjectDetailResponse createProject(ProjectRequest projectRequest) {
         File thumbnail = fileRepository.findById(projectRequest.getThumbnailId())
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT_THUMBNAIL));
@@ -36,10 +37,9 @@ public class ProjectService {
         return getProject(project.getId());
     }
 
-    @Transactional
     public ProjectDetailResponse getProject(Long projectId) {
         Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다"));
+                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT));
 
         List<String> studentNames = project.getMembers().stream()
                 .filter(member -> member.getRole() == Role.STUDENT)
@@ -53,7 +53,6 @@ public class ProjectService {
         return ProjectDetailResponse.of(studentNames, professerNames, project);
     }
 
-    @Transactional
     public ProjectDetailResponse updateProject(Long projectId, ProjectRequest projectRequest) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT));
@@ -69,7 +68,6 @@ public class ProjectService {
         return getProject(projectId);
     }
 
-    @Transactional
     public void deleteProject(Long projectId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT));

--- a/src/main/java/com/scg/stop/domain/project/service/ProjectService.java
+++ b/src/main/java/com/scg/stop/domain/project/service/ProjectService.java
@@ -37,6 +37,7 @@ public class ProjectService {
         return getProject(project.getId());
     }
 
+    @Transactional(readOnly = true)
     public ProjectDetailResponse getProject(Long projectId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT));

--- a/src/main/java/com/scg/stop/domain/project/service/ProjectService.java
+++ b/src/main/java/com/scg/stop/domain/project/service/ProjectService.java
@@ -2,12 +2,20 @@ package com.scg.stop.domain.project.service;
 
 import com.scg.stop.domain.file.domain.File;
 import com.scg.stop.domain.file.repository.FileRepository;
+import com.scg.stop.domain.project.domain.Member;
 import com.scg.stop.domain.project.domain.Project;
+import com.scg.stop.domain.project.domain.Role;
 import com.scg.stop.domain.project.dto.request.ProjectRequest;
+import com.scg.stop.domain.project.dto.response.ProjectDetailResponse;
 import com.scg.stop.domain.project.repository.ProjectRepository;
+import com.scg.stop.global.exception.BadRequestException;
+import com.scg.stop.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -15,15 +23,57 @@ public class ProjectService {
     private final ProjectRepository projectRepository;
     private final FileRepository fileRepository;
     @Transactional
-    public void createProject(ProjectRequest projectRequest) {
+    public ProjectDetailResponse createProject(ProjectRequest projectRequest) {
         File thumbnail = fileRepository.findById(projectRequest.getThumbnailId())
-                .orElseThrow(() -> new IllegalArgumentException("썸네일을 찾을 수 없습니다"));
+                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT_THUMBNAIL));
         File poster = fileRepository.findById(projectRequest.getPosterId())
-                .orElseThrow(() -> new IllegalArgumentException("포스터를 찾을 수 없습니다"));
+                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT_POSTER));
 
-        // ToDo: BadRequestException dev 브랜치에 있을듯..
-        Project project = projectRequest.toEntity(thumbnail, poster);
+        Project project = projectRequest.toEntity(null, thumbnail, poster);
 
         projectRepository.save(project);
+
+        return getProject(project.getId());
+    }
+
+    @Transactional
+    public ProjectDetailResponse getProject(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다"));
+
+        List<String> studentNames = project.getMembers().stream()
+                .filter(member -> member.getRole() == Role.STUDENT)
+                .map(Member::getName)
+                .collect(Collectors.toList());
+        List<String> professerNames = project.getMembers().stream()
+                .filter(member -> member.getRole() == Role.PROFESSOR)
+                .map(Member::getName)
+                .collect(Collectors.toList());
+
+        return ProjectDetailResponse.of(studentNames, professerNames, project);
+    }
+
+    @Transactional
+    public ProjectDetailResponse updateProject(Long projectId, ProjectRequest projectRequest) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT));
+
+        File thumbnail = fileRepository.findById(projectRequest.getThumbnailId())
+                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT_THUMBNAIL));
+        File poster = fileRepository.findById(projectRequest.getPosterId())
+                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT_POSTER));
+
+        Project newProject = projectRequest.toEntity(projectId, thumbnail, poster);
+        project.update(newProject);
+
+        return getProject(projectId);
+    }
+
+    @Transactional
+    public void deleteProject(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_PROJECT));
+
+        projectRepository.delete(project);
     }
 }

--- a/src/main/java/com/scg/stop/global/exception/ExceptionCode.java
+++ b/src/main/java/com/scg/stop/global/exception/ExceptionCode.java
@@ -9,7 +9,11 @@ public enum ExceptionCode {
 
     INVALID_REQUEST(1000, "요청 형식이 올바르지 않습니다."),
 
-    DUPLICATED_YEAR(1001, "해당 연도의 행사 기간이 이미 존재합니다.");
+    DUPLICATED_YEAR(1001, "해당 연도의 행사 기간이 이미 존재합니다."),
+
+    NOT_FOUND_PROJECT(77000, "프로젝트를 찾을 수 없습니다."),
+    NOT_FOUND_PROJECT_THUMBNAIL(77001, "프로젝트 썸네일을 찾을 수 없습니다"),
+    NOT_FOUND_PROJECT_POSTER(77001, "프로젝트 포스터를 찾을 수 없습니다");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/scg/stop/global/exception/ExceptionCode.java
+++ b/src/main/java/com/scg/stop/global/exception/ExceptionCode.java
@@ -13,7 +13,8 @@ public enum ExceptionCode {
 
     NOT_FOUND_PROJECT(77000, "프로젝트를 찾을 수 없습니다."),
     NOT_FOUND_PROJECT_THUMBNAIL(77001, "프로젝트 썸네일을 찾을 수 없습니다"),
-    NOT_FOUND_PROJECT_POSTER(77001, "프로젝트 포스터를 찾을 수 없습니다");
+    NOT_FOUND_PROJECT_POSTER(77002, "프로젝트 포스터를 찾을 수 없습니다"),
+    INVALID_MEMBER(77003, "멤버 정보가 올바르지 않습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/scg/stop/global/exception/ExceptionCode.java
+++ b/src/main/java/com/scg/stop/global/exception/ExceptionCode.java
@@ -14,7 +14,8 @@ public enum ExceptionCode {
     NOT_FOUND_PROJECT(77000, "프로젝트를 찾을 수 없습니다."),
     NOT_FOUND_PROJECT_THUMBNAIL(77001, "프로젝트 썸네일을 찾을 수 없습니다"),
     NOT_FOUND_PROJECT_POSTER(77002, "프로젝트 포스터를 찾을 수 없습니다"),
-    INVALID_MEMBER(77003, "멤버 정보가 올바르지 않습니다.");
+    INVALID_MEMBER(77003, "멤버 정보가 올바르지 않습니다."),
+    INVALID_TECHSTACK(77004, "기술 스택 정보가 올바르지 않습니다.");
 
     private final int code;
     private final String message;

--- a/src/test/java/com/scg/stop/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/scg/stop/domain/project/controller/ProjectControllerTest.java
@@ -1,0 +1,237 @@
+package com.scg.stop.domain.project.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scg.stop.configuration.AbstractControllerTest;
+import com.scg.stop.domain.project.domain.AwardStatus;
+import com.scg.stop.domain.project.domain.ProjectCategory;
+import com.scg.stop.domain.project.domain.ProjectType;
+import com.scg.stop.domain.project.domain.Role;
+import com.scg.stop.domain.project.dto.request.MemberRequest;
+import com.scg.stop.domain.project.dto.request.ProjectRequest;
+import com.scg.stop.domain.project.dto.response.ProjectDetailResponse;
+import com.scg.stop.domain.project.service.ProjectService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+@WebMvcTest(ProjectController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+public class ProjectControllerTest extends AbstractControllerTest {
+
+    @MockBean
+    private ProjectService projectService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // ToDo: getProjects() 코드가 base 브랜치에 있어서, 추후에 새로운 브랜치 만들어서 작성하기
+//    @DisplayName("간단한 프로젝트 리스트를 조회한다. | 페이지네이션")
+//    @Test
+//    void getProjects() throws Exception {
+//        // given
+//        // when
+//        // then
+//    }
+
+    @Test
+    @DisplayName("프로젝트를 생성한다.")
+    void createProject() throws Exception {
+        // given
+        List<MemberRequest> memberRequest = List.of(
+                new MemberRequest("테스트 학생 이름 1", Role.STUDENT),
+                new MemberRequest("테스트 학생 이름 2", Role.STUDENT),
+                new MemberRequest("테스트 교수 이름 1", Role.PROFESSOR)
+        );
+
+        ProjectRequest projectRequest = new ProjectRequest(1L, 2L, "테스트 프로젝트 이름", ProjectType.STARTUP, ProjectCategory.BIG_DATA_ANALYSIS, "테스트 팀 이름", "테스트 유튜브 ID", "테스트, 기술, 스택", 2021, AwardStatus.NONE, memberRequest);
+
+        ProjectDetailResponse response = new ProjectDetailResponse(1L, null, null, "테스트 프로젝트 이름", ProjectType.STARTUP, ProjectCategory.BIG_DATA_ANALYSIS, "테스트 팀 이름", "테스트 유튜브 ID", List.of("테스트", "기술", "스택"), 2021, AwardStatus.NONE, List.of("테스트 학생 이름 1", "테스트 학생 이름 2"), List.of("테스트 교수 이름 1"), 0, false);
+
+        when(projectService.createProject(any(ProjectRequest.class))).thenReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                post("/projects")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(projectRequest))
+        );
+
+        // then
+        result.andExpect(status().isCreated())
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("thumbnailId").description("썸네일 ID"),
+                                fieldWithPath("posterId").description("포스터 ID"),
+                                fieldWithPath("projectName").description("프로젝트 이름"),
+                                fieldWithPath("projectType").description("프로젝트 타입"),
+                                fieldWithPath("projectCategory").description("프로젝트 카테고리"),
+                                fieldWithPath("teamName").description("팀 이름"),
+                                fieldWithPath("youtubeId").description("프로젝트 yotubeId"),
+                                fieldWithPath("techStack").description("기술 스택"),
+                                fieldWithPath("year").description("프로젝트 년도"),
+                                fieldWithPath("awardStatus").description("수상 여부"),
+                                fieldWithPath("members").description("멤버"),
+                                fieldWithPath("members[].name").description("멤버 이름"),
+                                fieldWithPath("members[].role").description("멤버 역할")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("프로젝트 ID"),
+                                fieldWithPath("thumbnailInfo").description("썸네일 정보"),
+                                fieldWithPath("posterInfo").description("포스터 정보"),
+                                fieldWithPath("projectName").description("프로젝트 이름"),
+                                fieldWithPath("projectType").description("프로젝트 타입"),
+                                fieldWithPath("projectCategory").description("프로젝트 카테고리"),
+                                fieldWithPath("teamName").description("팀 이름"),
+                                fieldWithPath("youtubeId").description("프로젝트 yotubeId"),
+                                fieldWithPath("techStack").description("기술 스택"),
+                                fieldWithPath("year").description("프로젝트 년도"),
+                                fieldWithPath("awardStatus").description("수상 여부"),
+                                fieldWithPath("sutudentNames").description("학생 이름"),
+                                fieldWithPath("professorNames").description("교수 이름"),
+                                fieldWithPath("likeCount").description("좋아요 수"),
+                                fieldWithPath("bookMark").description("북마크 여부")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("상세 프로젝트 정보를 조회한다.")
+    void getProject() throws Exception {
+        // given
+        ProjectDetailResponse response = new ProjectDetailResponse(1L, null, null, "테스트 프로젝트 이름", ProjectType.STARTUP, ProjectCategory.BIG_DATA_ANALYSIS, "테스트 팀 이름", "테스트 유튜브 ID", List.of("테스트", "기술", "스택"), 2021, AwardStatus.NONE, List.of("테스트 학생 이름 1", "테스트 학생 이름 2"), List.of("테스트 교수 이름 1"), 0, false);
+
+        when(projectService.getProject(anyLong())).thenReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/projects/{projectId}", 1L)
+                        .contentType(APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("projectId").description("프로젝트 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("프로젝트 ID"),
+                                fieldWithPath("thumbnailInfo").description("썸네일 정보"),
+                                fieldWithPath("posterInfo").description("포스터 정보"),
+                                fieldWithPath("projectName").description("프로젝트 이름"),
+                                fieldWithPath("projectType").description("프로젝트 타입"),
+                                fieldWithPath("projectCategory").description("프로젝트 카테고리"),
+                                fieldWithPath("teamName").description("팀 이름"),
+                                fieldWithPath("youtubeId").description("프로젝트 yotubeId"),
+                                fieldWithPath("techStack").description("기술 스택"),
+                                fieldWithPath("year").description("프로젝트 년도"),
+                                fieldWithPath("awardStatus").description("수상 여부"),
+                                fieldWithPath("sutudentNames").description("학생 이름"),
+                                fieldWithPath("professorNames").description("교수 이름"),
+                                fieldWithPath("likeCount").description("좋아요 수"),
+                                fieldWithPath("bookMark").description("북마크 여부")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("상세 프로젝트 정보를 수정한다.")
+    void updateProject() throws Exception {
+        // given
+        List<MemberRequest> memberRequest = List.of(
+                new MemberRequest("테스트 학생 이름 1", Role.STUDENT),
+                new MemberRequest("테스트 학생 이름 2", Role.STUDENT),
+                new MemberRequest("테스트 교수 이름 1", Role.PROFESSOR)
+        );
+
+        ProjectRequest projectRequest = new ProjectRequest(1L, 2L, "테스트 프로젝트 이름", ProjectType.STARTUP, ProjectCategory.BIG_DATA_ANALYSIS, "테스트 팀 이름", "테스트 유튜브 ID", "테스트, 기술, 스택", 2021, AwardStatus.NONE, memberRequest);
+
+        ProjectDetailResponse response = new ProjectDetailResponse(1L, null, null, "테스트 프로젝트 이름", ProjectType.STARTUP, ProjectCategory.BIG_DATA_ANALYSIS, "테스트 팀 이름", "테스트 유튜브 ID", List.of("테스트", "기술", "스택"), 2021, AwardStatus.NONE, List.of("테스트 학생 이름 1", "테스트 학생 이름 2"), List.of("테스트 교수 이름 1"), 0, false);
+
+        when(projectService.updateProject(anyLong(), any(ProjectRequest.class))).thenReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                put("/projects/{projectId}", 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(projectRequest))
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("thumbnailId").description("썸네일 ID"),
+                                fieldWithPath("posterId").description("포스터 ID"),
+                                fieldWithPath("projectName").description("프로젝트 이름"),
+                                fieldWithPath("projectType").description("프로젝트 타입"),
+                                fieldWithPath("projectCategory").description("프로젝트 카테고리"),
+                                fieldWithPath("teamName").description("팀 이름"),
+                                fieldWithPath("youtubeId").description("프로젝트 yotubeId"),
+                                fieldWithPath("techStack").description("기술 스택"),
+                                fieldWithPath("year").description("프로젝트 년도"),
+                                fieldWithPath("awardStatus").description("수상 여부"),
+                                fieldWithPath("members").description("멤버"),
+                                fieldWithPath("members[].name").description("멤버 이름"),
+                                fieldWithPath("members[].role").description("멤버 역할")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("프로젝트 ID"),
+                                fieldWithPath("thumbnailInfo").description("썸네일 정보"),
+                                fieldWithPath("posterInfo").description("포스터 정보"),
+                                fieldWithPath("projectName").description("프로젝트 이름"),
+                                fieldWithPath("projectType").description("프로젝트 타입"),
+                                fieldWithPath("projectCategory").description("프로젝트 카테고리"),
+                                fieldWithPath("teamName").description("팀 이름"),
+                                fieldWithPath("youtubeId").description("프로젝트 yotubeId"),
+                                fieldWithPath("techStack").description("기술 스택"),
+                                fieldWithPath("year").description("프로젝트 년도"),
+                                fieldWithPath("awardStatus").description("수상 여부"),
+                                fieldWithPath("sutudentNames").description("학생 이름"),
+                                fieldWithPath("professorNames").description("교수 이름"),
+                                fieldWithPath("likeCount").description("좋아요 수"),
+                                fieldWithPath("bookMark").description("북마크 여부")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("프로젝트를 삭제한다.")
+    void deleteProject() throws Exception {
+        // given
+        doNothing().when(projectService).deleteProject(anyLong());
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/projects/{projectId}", 1L)
+                        .contentType(APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isNoContent())
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("projectId").description("프로젝트 ID")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/scg/stop/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/scg/stop/domain/project/controller/ProjectControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.scg.stop.configuration.AbstractControllerTest;
+
 import com.scg.stop.domain.project.domain.AwardStatus;
 import com.scg.stop.domain.project.domain.ProjectCategory;
 import com.scg.stop.domain.project.domain.ProjectType;
@@ -27,7 +28,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
-import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
@@ -79,7 +80,7 @@ public class ProjectControllerTest extends AbstractControllerTest {
         result.andExpect(status().isCreated())
                 .andDo(restDocs.document(
                         requestFields(
-                                fieldWithPath("thumbnailId").description("썸네일 ID"),
+                                fieldWithPath("thumbnailId").type(JsonFieldType.NUMBER).description("썸네일 ID"),
                                 fieldWithPath("posterId").description("포스터 ID"),
                                 fieldWithPath("projectName").description("프로젝트 이름"),
                                 fieldWithPath("projectType").description("프로젝트 타입"),


### PR DESCRIPTION
작성자: @yeobi01 

#7

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

### Project API 4개 구현 (DTO, Repository, Service, Controller, RestDocs)
- 4개의 API(createProject, getProject, updateProject, deleteProject)를 하나의 브랜치에서 작업했습니다.

## 비고

- updateProject service 부분에서 project.update 메서드를 작성할 때, 파라미터가 너무 많아서 getter를 써야할지 / 파라미터를 모두 넘겨줘야할지 고민하다가, 변경될 부분들이 고려된 request 객체를 entity를 생성해서 파라미터로 넘겨주고, 업데이트 하는식으로 코드를 작성했습니다. 이 부분에 대해서 의견 주시면 감사하겠습니다!
