### PR TITLE
[FEAT] updateApplication API, restdocs 구현

### DIFF
--- a/src/docs/asciidoc/application.adoc
+++ b/src/docs/asciidoc/application.adoc
@@ -6,7 +6,11 @@
 ====
 operation::application-controller-test/get-applications[snippets="http-request,query-parameters,http-response,response-fields"]
 ====
-=== 인증 신청자 상세 정보 조회 (GET /applications)
+=== 인증 신청자 상세 정보 조회 (GET /applications/{applicationId})
 ====
 operation::application-controller-test/get-application[snippets="http-request,path-parameters,http-response,response-fields"]
+====
+=== 교수/기업 인증 (GET /applications/{applicationId})
+====
+operation::application-controller-test/update-application[snippets="http-request,path-parameters,http-response,response-fields"]
 ====

--- a/src/main/java/com/scg/stop/domain/user/controller/ApplicationController.java
+++ b/src/main/java/com/scg/stop/domain/user/controller/ApplicationController.java
@@ -23,15 +23,27 @@ public class ApplicationController {
     @GetMapping
     public ResponseEntity<Page<ApplicationListResponse>> getApplications(
             @PageableDefault(page = 0, size = 10) Pageable pageable
-            // TODO @AuthUser(accessType = {AccessType.ADMIN}) User.user
+            // TODO @AuthUser(accessType = {AccessType.ADMIN}) user
     ) {
         Page<ApplicationListResponse> applications = applicationService.getApplications(pageable);
         return ResponseEntity.ok().body(applications);
     }
 
-//    @GetMapping("/{applicationId}")
-//    public void getApplication(@PathVariable String applicationId) {}
-//
-//    @PatchMapping("/{applicationId}")
-//    public void updateApplication(@PathVariable String applicationId) {}
+    @GetMapping("/{applicationId}")
+    public ResponseEntity<ApplicationDetailResponse> getApplication(
+            @PathVariable("applicationId") Long applicationId
+            // TODO @AuthUser(accessType = {AccessType.ADMIN}) user
+    ) {
+        ApplicationDetailResponse application = applicationService.getApplication(applicationId);
+        return ResponseEntity.ok().body(application);
+    }
+
+    @PatchMapping("/{applicationId}")
+    public ResponseEntity<ApplicationDetailResponse> updateApplication(
+            @PathVariable("applicationId") Long applicationId
+            // TODO @AuthUser(accessType = {AccessType.ADMIN}) user
+    ) {
+        ApplicationDetailResponse application = applicationService.updateApplication(applicationId);
+        return ResponseEntity.ok().body(application);
+    }
 }

--- a/src/main/java/com/scg/stop/domain/user/domain/User.java
+++ b/src/main/java/com/scg/stop/domain/user/domain/User.java
@@ -78,4 +78,12 @@ public class User extends BaseTimeEntity {
 
     @OneToMany(fetch = LAZY, mappedBy = "user")
     private List<Inquiry> inquiries = new ArrayList<>();
+
+    public void updateApplication() {
+        if (userType == UserType.INACTIVE_COMPANY) {
+            userType = UserType.COMPANY;
+        } else if (userType == UserType.INACTIVE_PROFESSOR) {
+            userType = UserType.PROFESSOR;
+        }
+    }
 }

--- a/src/main/java/com/scg/stop/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/scg/stop/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.scg.stop.domain.user.repository;
+
+import com.scg.stop.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/scg/stop/domain/user/service/ApplicationService.java
+++ b/src/main/java/com/scg/stop/domain/user/service/ApplicationService.java
@@ -7,8 +7,12 @@ import com.scg.stop.domain.user.domain.User;
 import com.scg.stop.domain.user.domain.UserType;
 import com.scg.stop.domain.user.dto.response.ApplicationListResponse;
 import com.scg.stop.domain.user.repository.ApplicationRepository;
+import com.scg.stop.domain.user.repository.UserRepository;
+import com.scg.stop.global.exception.BadRequestException;
+import com.scg.stop.global.exception.ExceptionCode;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,10 +25,38 @@ import org.springframework.transaction.annotation.Transactional;
 public class ApplicationService {
 
     private final ApplicationRepository applicationRepository;
+    private final UserRepository userRepository;
 
     public Page<ApplicationListResponse> getApplications(Pageable pageable) {
         List<UserType> targetUserTypes = Arrays.asList(INACTIVE_COMPANY, INACTIVE_PROFESSOR);
         Page<Application> filteredApplications = applicationRepository.findByUserTypeIn(targetUserTypes, pageable);
         return filteredApplications.map(ApplicationListResponse::from);
+    }
+
+    public ApplicationDetailResponse getApplication(Long applicationId) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_APPLICATION_ID));
+
+        List<UserType> activeUserTypes = Arrays.asList(COMPANY, PROFESSOR);
+        if(activeUserTypes.contains(application.getUser().getUserType())) {
+            throw new BadRequestException(ALREADY_VERIFIED_USER);
+        }
+        return ApplicationDetailResponse.from(application);
+    }
+
+    @Transactional
+    public ApplicationDetailResponse updateApplication(Long applicationId) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_APPLICATION_ID));
+
+        User user = application.getUser();
+        List<UserType> activeUserTypes = Arrays.asList(COMPANY, PROFESSOR);
+        if(activeUserTypes.contains(user.getUserType())) {
+            throw new BadRequestException(ALREADY_VERIFIED_USER);
+        }
+
+        user.updateApplication();
+        userRepository.save(user);
+        return ApplicationDetailResponse.from(application);
     }
 }

--- a/src/test/java/com/scg/stop/domain/user/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/scg/stop/domain/user/controller/ApplicationControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -145,6 +146,42 @@ class ApplicationControllerTest extends AbstractControllerTest {
                                 fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("인증 신청 정보 수정일")
                         )
                 ));
+    }
 
+    // TODO Auth 설정 추가
+    @Test
+    @DisplayName("교수/기업 인증")
+    void updateApplication() throws Exception {
+
+        // given
+        Long applicationId = 1L;
+        ApplicationDetailResponse response = new ApplicationDetailResponse(
+                applicationId, "김영한", "010-1111-2222", "email@gmail.com", "배민", "CEO", UserType.COMPANY, LocalDateTime.now(), LocalDateTime.now()
+        );
+
+        when(applicationService.updateApplication(applicationId)).thenReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/applications/{applicationId}", applicationId)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("applicationId").description("인증 신청 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("인증 신청 ID"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("인증 신청자 이름"),
+                                fieldWithPath("phone").type(JsonFieldType.STRING).description("인증 신청자 전화번호"),
+                                fieldWithPath("email").type(JsonFieldType.STRING).description("인증 신청자 이메일"),
+                                fieldWithPath("division").type(JsonFieldType.STRING).description("소속").optional(),
+                                fieldWithPath("position").type(JsonFieldType.STRING).description("직책").optional(),
+                                fieldWithPath("userType").type(JsonFieldType.STRING).description("회원 유형 [PROFESSOR, COMPANY]"),
+                                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("인증 신청 정보 생성일"),
+                                fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("인증 신청 정보 수정일")
+                        )
+                ));
     }
 }


### PR DESCRIPTION
작성자: @yesjuhee 

- 연관 이슈 : #5 
- PR #29 에 이어서 작성했습니다!

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [ ] Target Branch를 올바르게 설정했나요? -> `feat/5-application-api/1` 머지 되면 base로 변경하겠습니다
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- updateApplication API : 교수/기업 인증 신청 API입니다. 관리자 페이지에서 가입 승인 버튼을 누르면 UserType을 변경시킵니다.

## 비고

- 지금 피그마에는 가입 신청 정보 삭제가 있는데 이거를 삭제해도 될지는 좀 고민이어서 수요일에 논의 후 결정하겠습니다
