### PR TITLE
[FEAT] getFile API, restdocs 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ out/
 ### VS Code ###
 .vscode/
 
-/src/main/resources/application-local.yml
 /src/main/resources/application-oauth.yml
 /src/main/resources/application-minio.yml
 /src/main/resources/static/docs/

--- a/src/docs/asciidoc/file-controller-test.adoc
+++ b/src/docs/asciidoc/file-controller-test.adoc
@@ -7,3 +7,8 @@
 ====
 operation::file-controller-test/upload-file[snippets="http-request,request-parts,http-response,response-fields"]
 ====
+
+=== 파일 조회 (GET /files/{fileId})
+====
+operation::file-controller-test/get-file[snippets="http-request,path-parameters,http-response"]
+====

--- a/src/main/java/com/scg/stop/file/controller/FileController.java
+++ b/src/main/java/com/scg/stop/file/controller/FileController.java
@@ -1,10 +1,16 @@
 package com.scg.stop.file.controller;
 
+import com.scg.stop.file.domain.File;
 import com.scg.stop.file.dto.response.FileResponse;
 import com.scg.stop.file.service.FileService;
+import java.io.InputStream;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -22,5 +28,14 @@ public class FileController {
     public ResponseEntity<FileResponse> uploadFile(@RequestPart("file") MultipartFile file) {
         FileResponse response = fileService.uploadFile(file);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{fileId}")
+    public ResponseEntity<InputStreamResource> getFile(@PathVariable("fileId") Long fileId) {
+        InputStream stream = fileService.getFile(fileId);
+        File file = fileService.getFileMetadata(fileId);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(file.getMimeType()))
+                .body(new InputStreamResource(stream));
     }
 }

--- a/src/main/java/com/scg/stop/file/service/FileService.java
+++ b/src/main/java/com/scg/stop/file/service/FileService.java
@@ -1,8 +1,12 @@
 package com.scg.stop.file.service;
 
+import static com.scg.stop.global.exception.ExceptionCode.FILE_NOT_FOUND;
+
 import com.scg.stop.file.domain.File;
 import com.scg.stop.file.dto.response.FileResponse;
 import com.scg.stop.file.repository.FileRepository;
+import com.scg.stop.global.exception.BadRequestException;
+import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -26,5 +30,10 @@ public class FileService {
         File fileInfo = File.of(uuid.toString(), file.getOriginalFilename(), file.getContentType());
         fileRepository.save(fileInfo);
         return FileResponse.from(fileInfo);
+    }
+
+    public InputStream getFile(Long fileId) {
+        File file = fileRepository.findById(fileId).orElseThrow(() -> new BadRequestException(FILE_NOT_FOUND));
+        return minioClientService.getFile(file.getUuid());
     }
 }

--- a/src/main/java/com/scg/stop/file/service/FileService.java
+++ b/src/main/java/com/scg/stop/file/service/FileService.java
@@ -36,4 +36,8 @@ public class FileService {
         File file = fileRepository.findById(fileId).orElseThrow(() -> new BadRequestException(FILE_NOT_FOUND));
         return minioClientService.getFile(file.getUuid());
     }
+
+    public File getFileMetadata(Long fileId) {
+        return fileRepository.findById(fileId).orElseThrow(() -> new BadRequestException(FILE_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/scg/stop/global/exception/ExceptionCode.java
+++ b/src/main/java/com/scg/stop/global/exception/ExceptionCode.java
@@ -24,7 +24,9 @@ public enum ExceptionCode {
     NOT_FOUND_DEPARTMENT(4003, "학과가 존재하지 않습니다."),
     INVALID_STUDENTINFO(4004, "학과/학번 정보가 존재하지 않습니다."),
 
-    FAILED_TO_UPLOAD_FILE(5000, "파일 업로드에 실패했습니다.");
+    FAILED_TO_UPLOAD_FILE(5000, "파일 업로드를 실패했습니다."),
+    FAILED_TO_GET_FILE(5001, "파일 가져오기를 실패했습니다."),
+    FILE_NOT_FOUND(5002, "요청한 ID에 해당하는 파일이 존재하지 않습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:mysql://127.0.0.1:3307/stop
+    username: root
+    password: 1234
+  jpa:
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        default_batch_fetch_size: 15
+
+
+server.port: 8000

--- a/src/test/java/com/scg/stop/file/controller/FileControllerTest.java
+++ b/src/test/java/com/scg/stop/file/controller/FileControllerTest.java
@@ -1,17 +1,28 @@
 package com.scg.stop.file.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.description;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseBody;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.scg.stop.configuration.AbstractControllerTest;
+import com.scg.stop.file.domain.File;
 import com.scg.stop.file.dto.response.FileResponse;
 import com.scg.stop.file.service.FileService;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -21,6 +32,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -76,6 +88,39 @@ class FileControllerTest extends AbstractControllerTest {
                                 fieldWithPath("mimeType").type(JsonFieldType.STRING).description("파일의 MIME 타입"),
                                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("파일 생성일"),
                                 fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("파일 수정일")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("파일을 가져올 수 있다.")
+    void getFile() throws Exception {
+        // given
+        Long fileId = 1L;
+        String fileName = "s-top 로고.png";
+        String mimeType = "image/png";
+        byte[] fileContent = "[BINARY DATA - PNG IMAGE CONTENT]".getBytes(StandardCharsets.UTF_8);
+
+        InputStream stream = new ByteArrayInputStream(fileContent);
+        File file = File.of(UUID.randomUUID().toString(), fileName, mimeType);
+
+        when(fileService.getFile(fileId)).thenReturn(stream);
+        when(fileService.getFileMetadata(fileId)).thenReturn(file);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/files/{fileId}", fileId)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.parseMediaType(file.getMimeType())))
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("fileId").description("파일 ID")
+                        ),
+                        responseHeaders(
+                                headerWithName(HttpHeaders.CONTENT_TYPE).description("파일의 MIME 타입")
                         )
                 ));
     }


### PR DESCRIPTION
작성자: @yesjuhee 

- 연관 이슈 : #41 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- `GET /files/{fileId}`로 요청을 보내면 mysql의 파일 테이블을 참조해 fileId에 해당하는 파일의 uuid를 이용해 minIO에서 파일을 가져옵니다.

## 비고

- #53 이 아직 머지되지 않아서 타겟 브랜치를 `feat/41-file-api/1`로 우선 설정했습니다.
