### PR TITLE
[FIX] event notice file update 시 미포함된 파일 삭제되도록 수정

### DIFF
--- a/src/main/java/com/scg/stop/event/domain/EventNotice.java
+++ b/src/main/java/com/scg/stop/event/domain/EventNotice.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -36,7 +36,7 @@ public class EventNotice extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private boolean fixed;
 
-    @OneToMany(fetch = LAZY, mappedBy = "eventNotice", cascade = REMOVE, orphanRemoval = true)
+    @OneToMany(fetch = LAZY, mappedBy = "eventNotice", cascade = ALL, orphanRemoval = true)
     private List<File> files = new ArrayList<>();
 
     private EventNotice(String title, String content, Integer hitCount, boolean fixed, List<File> files) {


### PR DESCRIPTION
작성자: @shj1081

close #89

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- event notice domain 의 file cascade option 을 `REMOVAL` 에서 `All` 로 변경

## 비고
