### PR TITLE
[FIX] getProjects의 response에 year 추가

### DIFF
--- a/src/main/java/com/scg/stop/project/dto/response/ProjectResponse.java
+++ b/src/main/java/com/scg/stop/project/dto/response/ProjectResponse.java
@@ -22,6 +22,7 @@ public class ProjectResponse {
     private ProjectCategory projectCategory;
     private AwardStatus awardStatus;
     private List<String> techStacks;
+    private Integer year;
     private Integer likeCount;
     private Boolean like;
     private Boolean bookMark;
@@ -55,6 +56,7 @@ public class ProjectResponse {
                 project.getCategory(),
                 project.getAwardStatus(),
                 techStackList,
+                project.getYear(),
                 project.getLikes().size(),
                 like,
                 bookMark

--- a/src/test/java/com/scg/stop/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/scg/stop/project/controller/ProjectControllerTest.java
@@ -85,6 +85,7 @@ public class ProjectControllerTest extends AbstractControllerTest {
                 ProjectCategory.BIG_DATA_ANALYSIS,
                 AwardStatus.FIRST,
                 List.of("파이썬", "SQL"),
+                2023,
                 100,
                 false,
                 false
@@ -105,6 +106,7 @@ public class ProjectControllerTest extends AbstractControllerTest {
                 ProjectCategory.AI_MACHINE_LEARNING,
                 AwardStatus.SECOND,
                 List.of("파이썬", "OpenCV"),
+                2023,
                 100,
                 false,
                 true
@@ -147,6 +149,7 @@ public class ProjectControllerTest extends AbstractControllerTest {
                                 fieldWithPath("content[].projectCategory").type(JsonFieldType.STRING).description("프로젝트 카테고리: COMPUTER_VISION, SYSTEM_NETWORK, WEB_APPLICATION, SECURITY_SOFTWARE_ENGINEERING, NATURAL_LANGUAGE_PROCESSING, BIG_DATA_ANALYSIS, AI_MACHINE_LEARNING, INTERACTION_AUGMENTED_REALITY"),
                                 fieldWithPath("content[].awardStatus").type(JsonFieldType.STRING).description("수상 여부: NONE, FIRST, SECOND, THIRD, FOURTH, FIFTH"),
                                 fieldWithPath("content[].techStacks").type(JsonFieldType.ARRAY).description("기술 스택"),
+                                fieldWithPath("content[].year").type(JsonFieldType.NUMBER).description("프로젝트 년도"),
                                 fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER).description("좋아요 수"),
                                 fieldWithPath("content[].like").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
                                 fieldWithPath("content[].bookMark").type(JsonFieldType.BOOLEAN).description("북마크 여부"),
@@ -761,6 +764,7 @@ public class ProjectControllerTest extends AbstractControllerTest {
                 ProjectCategory.BIG_DATA_ANALYSIS,
                 AwardStatus.FIRST,
                 List.of("파이썬", "SQL"),
+                2023,
                 100,
                 false,
                 false
@@ -781,6 +785,7 @@ public class ProjectControllerTest extends AbstractControllerTest {
                 ProjectCategory.AI_MACHINE_LEARNING,
                 AwardStatus.SECOND,
                 List.of("파이썬", "OpenCV"),
+                2023,
                 100,
                 false,
                 true
@@ -821,6 +826,7 @@ public class ProjectControllerTest extends AbstractControllerTest {
                                 fieldWithPath("content[].projectCategory").type(JsonFieldType.STRING).description("프로젝트 카테고리: COMPUTER_VISION, SYSTEM_NETWORK, WEB_APPLICATION, SECURITY_SOFTWARE_ENGINEERING, NATURAL_LANGUAGE_PROCESSING, BIG_DATA_ANALYSIS, AI_MACHINE_LEARNING, INTERACTION_AUGMENTED_REALITY"),
                                 fieldWithPath("content[].awardStatus").type(JsonFieldType.STRING).description("수상 여부: NONE, FIRST, SECOND, THIRD, FOURTH, FIFTH"),
                                 fieldWithPath("content[].techStacks").type(JsonFieldType.ARRAY).description("기술 스택"),
+                                fieldWithPath("content[].year").type(JsonFieldType.NUMBER).description("프로젝트 년도"),
                                 fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER).description("좋아요 수"),
                                 fieldWithPath("content[].like").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
                                 fieldWithPath("content[].bookMark").type(JsonFieldType.BOOLEAN).description("북마크 여부"),


### PR DESCRIPTION
작성자: @yeobi01 

close #93

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- ProjectResponse DTO에 year 맴버 추가

## 비고


