### PR TITLE
[CHORE] 레포 이름 변경으로 인한 restdocs 경로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # S-TOP backend
 
-[S-TOP Rest Docs](https://systemconsultantgroup.github.io/s-top-backend/src/main/resources/static/docs/index.html)
+[S-TOP Rest Docs](https://systemconsultantgroup.github.io/S-top-backend/src/main/resources/static/docs/index.html)


### PR DESCRIPTION
작성자: @yesjuhee 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- 레포 이름이 변경되어 리드미의 기존 Rest Docs 문서 링크가 안열리는 오류를 해결했습니다.

## 비고

- 간단한 수정사항이라 바로 머지하겠습니다.
