### PR TITLE
[FIX] 퀴즈 생성 및 응답 형식을 Json에서 List로 변경

### DIFF
--- a/src/main/java/com/scg/stop/video/dto/request/QuizRequest.java
+++ b/src/main/java/com/scg/stop/video/dto/request/QuizRequest.java
@@ -8,6 +8,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -19,16 +21,18 @@ public class QuizRequest {
     //@NotNull(message = "퀴즈를 입력해주세요.")
     @Size(min=1, message = "퀴즈는 1개 이상이어야 합니다.")
     @Valid
-    public Map<String,
-            @Valid QuizInfoRequest> quiz;
+    public List<@Valid QuizInfoRequest> quiz;
 
     public Quiz toEntity() { return Quiz.from(
             this.toQuizInfoMap()
     ); }
 
     public Map<String, QuizInfo> toQuizInfoMap() {
-        return quiz.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toQuizInfo()));
+        Map<String, QuizInfo> quizInfoMap = new HashMap<>();
+        for(int i = 0; i < quiz.size(); i++) {
+            quizInfoMap.put(Integer.toString(i), quiz.get(i).toQuizInfo());
+        }
+        return quizInfoMap;
     }
 
 }

--- a/src/main/java/com/scg/stop/video/dto/response/QuizResponse.java
+++ b/src/main/java/com/scg/stop/video/dto/response/QuizResponse.java
@@ -6,17 +6,23 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class QuizResponse {
-    public Map<String, QuizInfo> quiz;
-
+    public List<QuizInfo> quiz;
     public static QuizResponse from(Quiz quiz) {
-        return new QuizResponse(
-                quiz.getQuiz()
-        );
+        List<String> keys = new ArrayList<>(quiz.getQuiz().keySet());
+        Collections.sort(keys);
+        List<QuizInfo> tmp = new ArrayList<>();
+        for(String key : keys) {
+            tmp.add(quiz.getQuiz().get(key));
+        }
+        return new QuizResponse(tmp);
     }
 }

--- a/src/main/resources/static/docs/talk.html
+++ b/src/main/resources/static/docs/talk.html
@@ -455,7 +455,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /talks HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: admin_access_token
-Content-Length: 399
+Content-Length: 361
 Host: localhost:8080
 Cookie: refresh-token=refresh_token
 
@@ -465,18 +465,15 @@ Cookie: refresh-token=refresh_token
   "year" : 2024,
   "talkerBelonging" : "대담자 소속",
   "talkerName" : "대담자 성명",
-  "quiz" : {
-    "0" : {
-      "question" : "질문1",
-      "answer" : 0,
-      "options" : [ "선지1", "선지2" ]
-    },
-    "1" : {
-      "question" : "질문2",
-      "answer" : 0,
-      "options" : [ "선지1", "선지2" ]
-    }
-  }
+  "quiz" : [ {
+    "question" : "질문1",
+    "answer" : 0,
+    "options" : [ "선지1", "선지2" ]
+  }, {
+    "question" : "질문2",
+    "answer" : 0,
+    "options" : [ "선지1", "선지2" ]
+  } ]
 }</code></pre>
 </div>
 </div>
@@ -531,30 +528,24 @@ Cookie: refresh-token=refresh_token
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 데이터, 없는경우 null</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.question</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].question</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 질문</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.answer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].answer</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 인덱스</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.options</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].options</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 리스트</p></td>
@@ -571,7 +562,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 503
+Content-Length: 470
 
 {
   "id" : 1,
@@ -580,20 +571,17 @@ Content-Length: 503
   "year" : 2024,
   "talkerBelonging" : "대담자 소속",
   "talkerName" : "대담자 성명",
-  "quiz" : {
-    "0" : {
-      "question" : "질문1",
-      "answer" : 0,
-      "options" : [ "선지1", "선지2" ]
-    },
-    "1" : {
-      "question" : "질문2",
-      "answer" : 0,
-      "options" : [ "선지1", "선지2" ]
-    }
-  },
-  "createdAt" : "2024-09-19T19:31:37.924986",
-  "updatedAt" : "2024-09-19T19:31:37.924988"
+  "quiz" : [ {
+    "question" : "질문1",
+    "answer" : 0,
+    "options" : [ "선지1", "선지2" ]
+  }, {
+    "question" : "질문2",
+    "answer" : 0,
+    "options" : [ "선지1", "선지2" ]
+  } ],
+  "createdAt" : "2024-10-04T01:07:50.78259322",
+  "updatedAt" : "2024-10-04T01:07:50.782601152"
 }</code></pre>
 </div>
 </div>
@@ -654,30 +642,24 @@ Content-Length: 503
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 데이터, 없는경우 null</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.question</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].question</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 질문</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.answer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].answer</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 인덱스</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.options</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].options</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 리스트</p></td>
@@ -764,13 +746,11 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 1042
+Content-Length: 1005
 
 {
-  "totalPages" : 1,
   "totalElements" : 1,
-  "first" : true,
-  "last" : true,
+  "totalPages" : 1,
   "size" : 10,
   "content" : [ {
     "id" : 1,
@@ -780,20 +760,17 @@ Content-Length: 1042
     "talkerBelonging" : "대담자 소속",
     "talkerName" : "대담자 성명",
     "favorite" : true,
-    "quiz" : {
-      "0" : {
-        "question" : "질문1",
-        "answer" : 0,
-        "options" : [ "선지1", "선지2" ]
-      },
-      "1" : {
-        "question" : "질문2",
-        "answer" : 0,
-        "options" : [ "선지1", "선지2" ]
-      }
-    },
-    "createdAt" : "2024-09-19T19:31:37.933059",
-    "updatedAt" : "2024-09-19T19:31:37.93306"
+    "quiz" : [ {
+      "question" : "질문1",
+      "answer" : 0,
+      "options" : [ "선지1", "선지2" ]
+    }, {
+      "question" : "질문2",
+      "answer" : 0,
+      "options" : [ "선지1", "선지2" ]
+    } ],
+    "createdAt" : "2024-10-04T01:07:50.820922829",
+    "updatedAt" : "2024-10-04T01:07:50.820930169"
   } ],
   "number" : 0,
   "sort" : {
@@ -814,6 +791,8 @@ Content-Length: 1042
     "paged" : true,
     "unpaged" : false
   },
+  "first" : true,
+  "last" : true,
   "empty" : false
 }</code></pre>
 </div>
@@ -1001,30 +980,24 @@ Content-Length: 1042
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].quiz</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 데이터, 없는경우 null</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].quiz.*</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].quiz.*.question</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].quiz[].question</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 질문</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].quiz.*.answer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].quiz[].answer</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 인덱스</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].quiz.*.options</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].quiz[].options</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 리스트</p></td>
@@ -1094,7 +1067,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 524
+Content-Length: 492
 
 {
   "id" : 1,
@@ -1104,20 +1077,17 @@ Content-Length: 524
   "talkerBelonging" : "대담자 소속",
   "talkerName" : "대담자 성명",
   "favorite" : true,
-  "quiz" : {
-    "0" : {
-      "question" : "질문1",
-      "answer" : 0,
-      "options" : [ "선지1", "선지2" ]
-    },
-    "1" : {
-      "question" : "질문2",
-      "answer" : 0,
-      "options" : [ "선지1", "선지2" ]
-    }
-  },
-  "createdAt" : "2024-09-19T19:31:37.917905",
-  "updatedAt" : "2024-09-19T19:31:37.917907"
+  "quiz" : [ {
+    "question" : "질문1",
+    "answer" : 0,
+    "options" : [ "선지1", "선지2" ]
+  }, {
+    "question" : "질문2",
+    "answer" : 0,
+    "options" : [ "선지1", "선지2" ]
+  } ],
+  "createdAt" : "2024-10-04T01:07:50.744379752",
+  "updatedAt" : "2024-10-04T01:07:50.744388902"
 }</code></pre>
 </div>
 </div>
@@ -1184,30 +1154,24 @@ Content-Length: 524
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 데이터, 없는경우 null</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.question</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].question</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 질문</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.answer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].answer</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 인덱스</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.options</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].options</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 리스트</p></td>
@@ -1241,7 +1205,7 @@ Content-Length: 524
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /talks/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: admin_access_token
-Content-Length: 499
+Content-Length: 461
 Host: localhost:8080
 Cookie: refresh-token=refresh_token
 
@@ -1251,18 +1215,15 @@ Cookie: refresh-token=refresh_token
   "year" : 2024,
   "talkerBelonging" : "수정한 대담자 소속",
   "talkerName" : "수정한 대담자 성명",
-  "quiz" : {
-    "0" : {
-      "question" : "수정한 질문1",
-      "answer" : 0,
-      "options" : [ "수정한 선지1", "수정한 선지2" ]
-    },
-    "1" : {
-      "question" : "수정한 질문2",
-      "answer" : 0,
-      "options" : [ "수정한 선지1", "수정한 선지2" ]
-    }
-  }
+  "quiz" : [ {
+    "question" : "수정한 질문1",
+    "answer" : 0,
+    "options" : [ "수정한 선지1", "수정한 선지2" ]
+  }, {
+    "question" : "수정한 질문2",
+    "answer" : 0,
+    "options" : [ "수정한 선지1", "수정한 선지2" ]
+  } ]
 }</code></pre>
 </div>
 </div>
@@ -1339,30 +1300,24 @@ Cookie: refresh-token=refresh_token
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 데이터, 없는경우 null</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.question</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].question</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 질문</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.answer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].answer</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 인덱스</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.options</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].options</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 리스트</p></td>
@@ -1379,7 +1334,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 603
+Content-Length: 571
 
 {
   "id" : 1,
@@ -1388,20 +1343,17 @@ Content-Length: 603
   "year" : 2024,
   "talkerBelonging" : "수정한 대담자 소속",
   "talkerName" : "수정한 대담자 성명",
-  "quiz" : {
-    "0" : {
-      "question" : "수정한 질문1",
-      "answer" : 0,
-      "options" : [ "수정한 선지1", "수정한 선지2" ]
-    },
-    "1" : {
-      "question" : "수정한 질문2",
-      "answer" : 0,
-      "options" : [ "수정한 선지1", "수정한 선지2" ]
-    }
-  },
-  "createdAt" : "2024-09-19T19:31:37.880796",
-  "updatedAt" : "2024-09-19T19:31:37.880797"
+  "quiz" : [ {
+    "question" : "수정한 질문1",
+    "answer" : 0,
+    "options" : [ "수정한 선지1", "수정한 선지2" ]
+  }, {
+    "question" : "수정한 질문2",
+    "answer" : 0,
+    "options" : [ "수정한 선지1", "수정한 선지2" ]
+  } ],
+  "createdAt" : "2024-10-04T01:07:50.602876045",
+  "updatedAt" : "2024-10-04T01:07:50.602884038"
 }</code></pre>
 </div>
 </div>
@@ -1462,30 +1414,24 @@ Content-Length: 603
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 데이터, 없는경우 null</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.question</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].question</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 질문</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.answer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].answer</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 인덱스</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.options</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].options</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 리스트</p></td>
@@ -1604,21 +1550,18 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 243
+Content-Length: 205
 
 {
-  "quiz" : {
-    "0" : {
-      "question" : "질문1",
-      "answer" : 0,
-      "options" : [ "선지1", "선지2" ]
-    },
-    "1" : {
-      "question" : "질문2",
-      "answer" : 1,
-      "options" : [ "선지1", "선지2" ]
-    }
-  }
+  "quiz" : [ {
+    "question" : "질문1",
+    "answer" : 0,
+    "options" : [ "선지1", "선지2" ]
+  }, {
+    "question" : "질문2",
+    "answer" : 0,
+    "options" : [ "선지1", "선지2" ]
+  } ]
 }</code></pre>
 </div>
 </div>
@@ -1643,32 +1586,26 @@ Content-Length: 243
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 데이터</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 데이터, 없는경우 null</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.question</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].question</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 질문</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.answer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].answer</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 인덱스</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz.*.options</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>quiz[].options</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">퀴즈 1개의 정답선지 리스트</p></td>
 </tr>
 </tbody>
@@ -2012,7 +1949,7 @@ Content-Length: 41
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-09-04 13:10:00 +0900
+Last updated 2024-09-10 11:30:29 +0900
 </div>
 </div>
 </body>

--- a/src/test/java/com/scg/stop/video/controller/TalkControllerTest.java
+++ b/src/test/java/com/scg/stop/video/controller/TalkControllerTest.java
@@ -3,6 +3,7 @@ package com.scg.stop.video.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.scg.stop.configuration.AbstractControllerTest;
 import com.scg.stop.video.controller.TalkController;
+import com.scg.stop.video.domain.QuizInfo;
 import com.scg.stop.video.dto.request.QuizInfoRequest;
 import com.scg.stop.video.dto.request.QuizRequest;
 import com.scg.stop.video.dto.request.QuizSubmitRequest;
@@ -39,6 +40,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,12 +77,15 @@ public class TalkControllerTest extends AbstractControllerTest {
     void createTalk() throws Exception {
 
         //given
-        Map<String, QuizInfoRequest> quizData = new HashMap<>();
-        quizData.put("0", new QuizInfoRequest("질문1", 0, List.of("선지1","선지2")));
-        quizData.put("1", new QuizInfoRequest("질문2", 0, List.of("선지1","선지2")));
+        List<QuizInfoRequest> quizData = new ArrayList<>();
+        quizData.add(new QuizInfoRequest("질문1", 0, List.of("선지1","선지2")));
+        quizData.add(new QuizInfoRequest("질문2", 0, List.of("선지1","선지2")));
         QuizRequest quizRequest = new QuizRequest(quizData);
         QuizResponse quizResponse = new QuizResponse(
-                quizRequest.toQuizInfoMap()
+                List.of(
+                        new QuizInfo("질문1", 0, List.of("선지1","선지2")),
+                        new QuizInfo("질문2", 0, List.of("선지1","선지2"))
+                )
         );
         TalkRequest request= new TalkRequest("제목","유튜브 고유ID", 2024, "대담자 소속", "대담자 성명",quizRequest);
         TalkResponse response = new TalkResponse(1L, "제목", "유튜브 고유ID", 2024,  "대담자 소속","대담자 성명" ,quizResponse,LocalDateTime.now(), LocalDateTime.now());
@@ -113,11 +118,10 @@ public class TalkControllerTest extends AbstractControllerTest {
                                 fieldWithPath("year").type(JsonFieldType.NUMBER).description("대담 영상 연도"),
                                 fieldWithPath("talkerBelonging").type(JsonFieldType.STRING).description("대담자의 소속된 직장/단체"),
                                 fieldWithPath("talkerName").type(JsonFieldType.STRING).description("대담자의 성명"),
-                                fieldWithPath("quiz").type(JsonFieldType.OBJECT).description("퀴즈 데이터, 없는경우 null").optional(),
-                                fieldWithPath("quiz.*").type(JsonFieldType.OBJECT).description("퀴즈 1개").optional(),
-                                fieldWithPath("quiz.*.question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
-                                fieldWithPath("quiz.*.answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
-                                fieldWithPath("quiz.*.options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional()
+                                fieldWithPath("quiz").type(JsonFieldType.ARRAY).description("퀴즈 데이터, 없는경우 null").optional(),
+                                fieldWithPath("quiz[].question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
+                                fieldWithPath("quiz[].answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
+                                fieldWithPath("quiz[].options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional()
                         ),
                         responseFields(
                                 fieldWithPath("id").type(JsonFieldType.NUMBER).description("대담 영상 ID"),
@@ -126,11 +130,10 @@ public class TalkControllerTest extends AbstractControllerTest {
                                 fieldWithPath("year").type(JsonFieldType.NUMBER).description("대담 영상 연도"),
                                 fieldWithPath("talkerBelonging").type(JsonFieldType.STRING).description("대담자의 소속된 직장/단체"),
                                 fieldWithPath("talkerName").type(JsonFieldType.STRING).description("대담자의 성명"),
-                                fieldWithPath("quiz").type(JsonFieldType.OBJECT).description("퀴즈 데이터, 없는경우 null"),
-                                fieldWithPath("quiz.*").type(JsonFieldType.OBJECT).description("퀴즈 1개").optional(),
-                                fieldWithPath("quiz.*.question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
-                                fieldWithPath("quiz.*.answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
-                                fieldWithPath("quiz.*.options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional(),
+                                fieldWithPath("quiz").type(JsonFieldType.ARRAY).description("퀴즈 데이터, 없는경우 null").optional(),
+                                fieldWithPath("quiz[].question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
+                                fieldWithPath("quiz[].answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
+                                fieldWithPath("quiz[].options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional(),
                                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("대담 영상 생성일"),
                                 fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("대담 영상 수정일")
                         )
@@ -141,12 +144,11 @@ public class TalkControllerTest extends AbstractControllerTest {
     @DisplayName("대담 영상 리스트를 조회할 수 있다.")
     void getTalkList() throws Exception {
         //given
-        Map<String, QuizInfoRequest> quizData = new HashMap<>();
-        quizData.put("0", new QuizInfoRequest("질문1", 0, List.of("선지1","선지2")));
-        quizData.put("1", new QuizInfoRequest("질문2", 0, List.of("선지1","선지2")));
-        QuizRequest quizRequest = new QuizRequest(quizData);
         QuizResponse quizResponse = new QuizResponse(
-                quizRequest.toQuizInfoMap()
+                List.of(
+                        new QuizInfo("질문1", 0, List.of("선지1","선지2")),
+                        new QuizInfo("질문2", 0, List.of("선지1","선지2"))
+                )
         );
         TalkUserResponse response = new TalkUserResponse(1L, "제목", "유튜브 고유ID", 2024,  "대담자 소속","대담자 성명" ,true,quizResponse,LocalDateTime.now(), LocalDateTime.now());
         Page<TalkUserResponse> page = new PageImpl<>(List.of(response), PageRequest.of(0,10),1);
@@ -208,11 +210,10 @@ public class TalkControllerTest extends AbstractControllerTest {
                                 fieldWithPath("content[].talkerBelonging").type(JsonFieldType.STRING).description("대담자의 소속된 직장/단체"),
                                 fieldWithPath("content[].talkerName").type(JsonFieldType.STRING).description("대담자의 성명"),
                                 fieldWithPath("content[].favorite").type(JsonFieldType.BOOLEAN).description("관심한 대담영상의 여부"),
-                                fieldWithPath("content[].quiz").type(JsonFieldType.OBJECT).description("퀴즈 데이터, 없는경우 null"),
-                                fieldWithPath("content[].quiz.*").type(JsonFieldType.OBJECT).description("퀴즈 1개").optional(),
-                                fieldWithPath("content[].quiz.*.question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
-                                fieldWithPath("content[].quiz.*.answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
-                                fieldWithPath("content[].quiz.*.options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional(),
+                                fieldWithPath("content[].quiz").type(JsonFieldType.ARRAY).description("퀴즈 데이터, 없는경우 null").optional(),
+                                fieldWithPath("content[].quiz[].question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
+                                fieldWithPath("content[].quiz[].answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
+                                fieldWithPath("content[].quiz[].options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional(),
                                 fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("대담 영상 생성일"),
                                 fieldWithPath("content[].updatedAt").type(JsonFieldType.STRING).description("대담 영상 수정일")
                         )
@@ -224,11 +225,11 @@ public class TalkControllerTest extends AbstractControllerTest {
     void getTalk() throws Exception {
         //given
         Long id = 1L;
-        Map<String, QuizInfoRequest> quizData = new HashMap<>();
-        quizData.put("0", new QuizInfoRequest("질문1", 0, List.of("선지1","선지2")));
-        quizData.put("1", new QuizInfoRequest("질문2", 0, List.of("선지1","선지2")));
         QuizResponse quizResponse = new QuizResponse(
-                new QuizRequest(quizData).toQuizInfoMap()
+                List.of(
+                        new QuizInfo("질문1", 0, List.of("선지1","선지2")),
+                        new QuizInfo("질문2", 0, List.of("선지1","선지2"))
+                )
         );
         TalkUserResponse response = new TalkUserResponse(id, "제목", "유튜브 고유ID", 2024, "대담자 소속","대담자 성명" ,true,quizResponse,LocalDateTime.now(), LocalDateTime.now());
         when(talkService.getTalkById(anyLong(), any())).thenReturn(response);
@@ -263,11 +264,10 @@ public class TalkControllerTest extends AbstractControllerTest {
                                 fieldWithPath("talkerBelonging").type(JsonFieldType.STRING).description("대담자의 소속된 직장/단체"),
                                 fieldWithPath("talkerName").type(JsonFieldType.STRING).description("대담자의 성명"),
                                 fieldWithPath("favorite").type(JsonFieldType.BOOLEAN).description("관심한 대담영상의 여부"),
-                                fieldWithPath("quiz").type(JsonFieldType.OBJECT).description("퀴즈 데이터, 없는경우 null"),
-                                fieldWithPath("quiz.*").type(JsonFieldType.OBJECT).description("퀴즈 1개").optional(),
-                                fieldWithPath("quiz.*.question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
-                                fieldWithPath("quiz.*.answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
-                                fieldWithPath("quiz.*.options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional(),
+                                fieldWithPath("quiz").type(JsonFieldType.ARRAY).description("퀴즈 데이터, 없는경우 null").optional(),
+                                fieldWithPath("quiz[].question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
+                                fieldWithPath("quiz[].answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
+                                fieldWithPath("quiz[].options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional(),
                                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("대담 영상 생성일"),
                                 fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("대담 영상 수정일")
                         )
@@ -280,11 +280,16 @@ public class TalkControllerTest extends AbstractControllerTest {
     void updateTalk() throws Exception {
         //given
         Long id = 1L;
-        Map<String, QuizInfoRequest> quizData = new HashMap<>();
-        quizData.put("0", new QuizInfoRequest("수정한 질문1", 0, List.of("수정한 선지1","수정한 선지2")));
-        quizData.put("1", new QuizInfoRequest("수정한 질문2", 0, List.of("수정한 선지1","수정한 선지2")));
+        List<QuizInfoRequest> quizData = new ArrayList<>();
+        quizData.add(new QuizInfoRequest("수정한 질문1", 0, List.of("수정한 선지1","수정한 선지2")));
+        quizData.add(new QuizInfoRequest("수정한 질문2", 0, List.of("수정한 선지1","수정한 선지2")));
         QuizRequest quizRequest = new QuizRequest(quizData);
-        QuizResponse quizResponse = new QuizResponse(quizRequest.toQuizInfoMap());
+        QuizResponse quizResponse = new QuizResponse(
+                List.of(
+                        new QuizInfo("수정한 질문1", 0, List.of("수정한 선지1","수정한 선지2")),
+                        new QuizInfo("수정한 질문2", 0, List.of("수정한 선지1","수정한 선지2"))
+                )
+        );
         TalkRequest request= new TalkRequest("수정한 제목","수정한 유튜브 고유ID", 2024, "수정한 대담자 소속", "수정한 대담자 성명",quizRequest);
         TalkResponse response = new TalkResponse(id, "수정한 제목", "수정한 유튜브 고유ID", 2024, "수정한 대담자 소속","수정한 대담자 성명" ,quizResponse,LocalDateTime.now(), LocalDateTime.now());
         when(talkService.updateTalk(anyLong(), any(TalkRequest.class))).thenReturn(response);
@@ -318,11 +323,10 @@ public class TalkControllerTest extends AbstractControllerTest {
                                 fieldWithPath("year").type(JsonFieldType.NUMBER).description("대담 영상 연도"),
                                 fieldWithPath("talkerBelonging").type(JsonFieldType.STRING).description("대담자의 소속된 직장/단체"),
                                 fieldWithPath("talkerName").type(JsonFieldType.STRING).description("대담자의 성명"),
-                                fieldWithPath("quiz").type(JsonFieldType.OBJECT).description("퀴즈 데이터, 없는경우 null").optional(),
-                                fieldWithPath("quiz.*").type(JsonFieldType.OBJECT).description("퀴즈 1개").optional(),
-                                fieldWithPath("quiz.*.question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
-                                fieldWithPath("quiz.*.answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
-                                fieldWithPath("quiz.*.options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional()
+                                fieldWithPath("quiz").type(JsonFieldType.ARRAY).description("퀴즈 데이터, 없는경우 null").optional(),
+                                fieldWithPath("quiz[].question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
+                                fieldWithPath("quiz[].answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
+                                fieldWithPath("quiz[].options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional()
                         ),
                         responseFields(
                                 fieldWithPath("id").type(JsonFieldType.NUMBER).description("대담 영상 ID"),
@@ -331,11 +335,10 @@ public class TalkControllerTest extends AbstractControllerTest {
                                 fieldWithPath("year").type(JsonFieldType.NUMBER).description("대담 영상 연도"),
                                 fieldWithPath("talkerBelonging").type(JsonFieldType.STRING).description("대담자의 소속된 직장/단체"),
                                 fieldWithPath("talkerName").type(JsonFieldType.STRING).description("대담자의 성명"),
-                                fieldWithPath("quiz").type(JsonFieldType.OBJECT).description("퀴즈 데이터, 없는경우 null"),
-                                fieldWithPath("quiz.*").type(JsonFieldType.OBJECT).description("퀴즈 1개").optional(),
-                                fieldWithPath("quiz.*.question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
-                                fieldWithPath("quiz.*.answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
-                                fieldWithPath("quiz.*.options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional(),
+                                fieldWithPath("quiz").type(JsonFieldType.ARRAY).description("퀴즈 데이터, 없는경우 null").optional(),
+                                fieldWithPath("quiz[].question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
+                                fieldWithPath("quiz[].answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
+                                fieldWithPath("quiz[].options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional(),
                                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("대담 영상 생성일"),
                                 fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("대담 영상 수정일")
                         )
@@ -377,11 +380,11 @@ public class TalkControllerTest extends AbstractControllerTest {
     void getQuiz() throws Exception {
         //given
         Long id = 1L;
-        Map<String, QuizInfoRequest> quizData = new HashMap<>();
-        quizData.put("0", new QuizInfoRequest("질문1", 0, List.of("선지1","선지2")));
-        quizData.put("1", new QuizInfoRequest("질문2", 1, List.of("선지1","선지2")));
         QuizResponse quizResponse = new QuizResponse(
-                new QuizRequest(quizData).toQuizInfoMap()
+                List.of(
+                        new QuizInfo("질문1", 0, List.of("선지1","선지2")),
+                        new QuizInfo("질문2", 0, List.of("선지1","선지2"))
+                )
         );
         when(quizService.getQuiz(anyLong())).thenReturn(quizResponse);
 
@@ -398,11 +401,10 @@ public class TalkControllerTest extends AbstractControllerTest {
                                 parameterWithName("talkId").description("퀴즈를 가져올 대담 영상의 ID")
                         ),
                         responseFields(
-                                fieldWithPath("quiz").type(JsonFieldType.OBJECT).description("퀴즈 데이터"),
-                                fieldWithPath("quiz.*").type(JsonFieldType.OBJECT).description("퀴즈 1개"),
-                                fieldWithPath("quiz.*.question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문"),
-                                fieldWithPath("quiz.*.answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스"),
-                                fieldWithPath("quiz.*.options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트")
+                                fieldWithPath("quiz").type(JsonFieldType.ARRAY).description("퀴즈 데이터, 없는경우 null").optional(),
+                                fieldWithPath("quiz[].question").type(JsonFieldType.STRING).description("퀴즈 1개의 질문").optional(),
+                                fieldWithPath("quiz[].answer").type(JsonFieldType.NUMBER).description("퀴즈 1개의 정답선지 인덱스").optional(),
+                                fieldWithPath("quiz[].options").type(JsonFieldType.ARRAY).description("퀴즈 1개의 정답선지 리스트").optional()
                         )
                 ));
 


### PR DESCRIPTION
작성자: @2tle

close #103 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- QuizRequest / QuizResponse에 Map <-> List 변환 로직 작성

## 비고

- 채점 관련 로직때문에 퀴즈 제출은 본래 형태 그대로 유지합니다.