### PR TITLE
[FIX] Access Token이 Bearer null 인 경우 Optional이 작동하지 않음

### DIFF
--- a/src/main/java/com/scg/stop/auth/config/AuthUserArgumentResolver.java
+++ b/src/main/java/com/scg/stop/auth/config/AuthUserArgumentResolver.java
@@ -46,13 +46,16 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
         AccessType[] allowedTypes = Objects.requireNonNull(parameter.getParameterAnnotation(AuthUser.class)).accessType();
         List<AccessType> accessTypeList = Arrays.asList(allowedTypes);
 
-        if(accessTypeList.contains(AccessType.OPTIONAL) && !hasAccessToken(request)) {
+        String accessToken = extractAccessToken(request);
+        final String notLoginAccessToken = "null";
+        if(accessTypeList.contains(AccessType.OPTIONAL) &&
+                (!hasAccessToken(request) || accessToken.equalsIgnoreCase(notLoginAccessToken))
+        ) {
             return null;
         }
 
         String contextPath = request.getRequestURI();
         String refreshToken = extractRefreshToken(request);
-        String accessToken = extractAccessToken(request);
 
         //검증
         if (jwtUtil.isAccessTokenValid(accessToken)) {

--- a/src/main/java/com/scg/stop/auth/config/AuthUserArgumentResolver.java
+++ b/src/main/java/com/scg/stop/auth/config/AuthUserArgumentResolver.java
@@ -46,15 +46,13 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
         AccessType[] allowedTypes = Objects.requireNonNull(parameter.getParameterAnnotation(AuthUser.class)).accessType();
         List<AccessType> accessTypeList = Arrays.asList(allowedTypes);
 
-        String accessToken = extractAccessToken(request);
-        final String notLoginAccessToken = "null";
-        if(accessTypeList.contains(AccessType.OPTIONAL) &&
-                (!hasAccessToken(request) || accessToken.equalsIgnoreCase(notLoginAccessToken))
-        ) {
+        if(accessTypeList.contains(AccessType.OPTIONAL) && !hasAccessToken(request))
+        {
             return null;
         }
 
         String contextPath = request.getRequestURI();
+        String accessToken = extractAccessToken(request);
         String refreshToken = extractRefreshToken(request);
 
         //검증
@@ -132,7 +130,8 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     private boolean hasAccessToken(HttpServletRequest request) {
         final String BEARER = "Bearer ";
+        final String BEARER_NULL = "Bearer null";
         String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-        return authHeader != null && authHeader.startsWith(BEARER);
+        return authHeader != null && authHeader.startsWith(BEARER) && !authHeader.equalsIgnoreCase(BEARER_NULL);
     }
 }


### PR DESCRIPTION
작성자: @2tle

close #127 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- accessToken 추출하는 위치 변경
- Optional 검사시, 추출한 access token이 문자열 null 인지 검사하는 로직 추가

## 비고

- 프론트엔드에서 로그인 안한 상태에서는 access token이 문자열 null로 들어옵니다. 이 문제를 해결하기 위해 null 문자열 검증 로직을 추가했는데, 혹시 더 좋은 의견 있으시면 아무나 댓글 달아주시면 감사하겠습니다
