### PR TITLE
[FIX] Proposal 검색 필터 조건 추가

### DIFF
--- a/src/main/java/com/scg/stop/proposal/repository/ProposalRepositoryCustomImpl.java
+++ b/src/main/java/com/scg/stop/proposal/repository/ProposalRepositoryCustomImpl.java
@@ -24,7 +24,7 @@ public class ProposalRepositoryCustomImpl implements ProposalRepositoryCustom {
             predicate = switch (scope) {
                 case "author" -> proposal.user.name.contains(term);
                 case "title" -> proposal.title.contains(term);
-                case "both" -> proposal.title.contains(term).or(proposal.content.contains(term));
+                case "both" -> proposal.title.contains(term).or(proposal.content.contains(term)).or(proposal.user.name.contains(term));
                 case "content" -> proposal.content.contains(term);
                 default -> throw new IllegalArgumentException("Invalid scope");
             };


### PR DESCRIPTION
작성자: @2tle

#135

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- Proposal의 both 검색 조건에서, 작성자 이름으로 필터링 하는 부분이 없어 추가했습니다.
- `ProposalRepositoryCustomImpl.java`
```
case "both" -> proposal.title.contains(term).or(proposal.content.contains(term)).or(proposal.user.name.contains(term));
```

## 비고

- 
