### PR TITLE
[FEAT] 대담영상/잡페어 인터뷰 영상 최신순 정렬

### DIFF
--- a/src/main/java/com/scg/stop/video/repository/JobInterviewRepository.java
+++ b/src/main/java/com/scg/stop/video/repository/JobInterviewRepository.java
@@ -14,7 +14,8 @@ public interface JobInterviewRepository extends JpaRepository<JobInterview, Long
     @Query("SELECT j FROM JobInterview j " +
             "WHERE (:year IS NULL OR j.year = :year) " +
             "AND (:category IS NULL OR j.category = :category) " +
-            "AND (:title IS NULL OR j.title LIKE %:title%)")
+            "AND (:title IS NULL OR j.title LIKE %:title%)" +
+            "ORDER BY j.year DESC")
     Page<JobInterview> findJobInterviews(@Param("year") Integer year,
                                                  @Param("category") JobInterviewCategory category,
                                                  @Param("title") String title,

--- a/src/main/java/com/scg/stop/video/repository/TalkRepository.java
+++ b/src/main/java/com/scg/stop/video/repository/TalkRepository.java
@@ -12,7 +12,8 @@ public interface TalkRepository extends JpaRepository<Talk, Long> {
 
     @Query("SELECT t from Talk t "+
             "WHERE (:year IS NULL OR t.year = :year) " +
-            "AND (:title IS NULL OR t.title LIKE %:title%)")
+            "AND (:title IS NULL OR t.title LIKE %:title%)" +
+            "ORDER BY t.year DESC")
     Page<Talk> findPages(
             @Param("title") String title,
             @Param("year") Integer year,


### PR DESCRIPTION
작성자: @2tle 

close #142 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- 대담영상과 잡페어 인터뷰가 최신순으로 정렬되도록 jpql 쿼리를 수정했습니다.

## 비고

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
