### PR TITLE
[FIX] 올해 프로젝트 조회시 순서 랜덤하게 응답

### DIFF
--- a/src/main/java/com/scg/stop/project/repository/ProjectRepository.java
+++ b/src/main/java/com/scg/stop/project/repository/ProjectRepository.java
@@ -27,18 +27,18 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
             Pageable pageable
     );
 
-    @Query(value = "SELECT p.* FROM project p " +
+    @Query("SELECT p FROM Project p " +
             "WHERE (:title IS NULL OR p.name LIKE %:title%) " +
             "AND (:year IS NULL OR p.year IN :year) " +
             "AND (:category IS NULL OR p.category IN :category) " +
             "AND (:type IS NULL OR p.type IN :type) " +
-            "ORDER BY MOD(UNIX_TIMESTAMP(NOW()) DIV 3600, p.id)",
-            nativeQuery = true)
+            "ORDER BY FUNCTION('RAND', :seed)")
     Page<Project> findEventProjects(
             @Param("title") String title,
             @Param("year") List<Integer> year,
             @Param("category") List<ProjectCategory> category,
             @Param("type") List<ProjectType> type,
+            @Param("seed") Integer seed,
             Pageable pageable
     );
 

--- a/src/main/java/com/scg/stop/project/repository/ProjectRepository.java
+++ b/src/main/java/com/scg/stop/project/repository/ProjectRepository.java
@@ -27,6 +27,21 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
             Pageable pageable
     );
 
+    @Query(value = "SELECT p.* FROM project p " +
+            "WHERE (:title IS NULL OR p.name LIKE %:title%) " +
+            "AND (:year IS NULL OR p.year IN :year) " +
+            "AND (:category IS NULL OR p.category IN :category) " +
+            "AND (:type IS NULL OR p.type IN :type) " +
+            "ORDER BY MOD(UNIX_TIMESTAMP(NOW()) DIV 3600, p.id)",
+            nativeQuery = true)
+    Page<Project> findEventProjects(
+            @Param("title") String title,
+            @Param("year") List<Integer> year,
+            @Param("category") List<ProjectCategory> category,
+            @Param("type") List<ProjectType> type,
+            Pageable pageable
+    );
+
     @Query("SELECT p FROM Project p " +
             "WHERE p.year = :year " +
             "AND p.awardStatus != com.scg.stop.project.domain.AwardStatus.NONE")

--- a/src/main/java/com/scg/stop/project/service/ProjectService.java
+++ b/src/main/java/com/scg/stop/project/service/ProjectService.java
@@ -61,8 +61,9 @@ public class ProjectService {
     @Transactional(readOnly = true)
     public Page<ProjectResponse> getProjects(String title, List<Integer> year, List<ProjectCategory> category, List<ProjectType> type, Pageable pageable, User user){
         boolean isEvent = year != null && year.size() == 1 && year.get(0) == LocalDateTime.now().getYear();
+        Integer seed = (int) Math.floor(LocalDateTime.now().getHour() / 1.0);
         Page<Project> projects = isEvent
-                ? projectRepository.findEventProjects(title, year, category, type, pageable)
+                ? projectRepository.findEventProjects(title, year, category, type, seed, pageable)
                 : projectRepository.findProjects(title, year, category, type, pageable);
 
         Page<ProjectResponse> projectResponses = projects.map(project -> ProjectResponse.of(user, project));

--- a/src/main/java/com/scg/stop/project/service/ProjectService.java
+++ b/src/main/java/com/scg/stop/project/service/ProjectService.java
@@ -60,7 +60,11 @@ public class ProjectService {
 
     @Transactional(readOnly = true)
     public Page<ProjectResponse> getProjects(String title, List<Integer> year, List<ProjectCategory> category, List<ProjectType> type, Pageable pageable, User user){
-        Page<Project> projects = projectRepository.findProjects(title, year, category, type, pageable);
+        boolean isEvent = year != null && year.size() == 1 && year.get(0) == LocalDateTime.now().getYear();
+        Page<Project> projects = isEvent
+                ? projectRepository.findEventProjects(title, year, category, type, pageable)
+                : projectRepository.findProjects(title, year, category, type, pageable);
+
         Page<ProjectResponse> projectResponses = projects.map(project -> ProjectResponse.of(user, project));
         return projectResponses;
     }


### PR DESCRIPTION
작성자: @yeobi01 

#139 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- ProjectRepository에서 seed 값에 따라 순서를 결정하여 올해의 프로젝트를 가져오는 JPQL 작성
- ProjectService에서 쿼리 파라미터 year 값으로 올해가 들어왔을 때 findProjects와 findEventProjects 분기처리

## 비고

- 
